### PR TITLE
Allow arbitrary transformer model for lexing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,147 @@
+local
+.vscode
+*.code-workspace
+
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+pip-wheel-metadata/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+.pybuilder/
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/
+
+# static files generated from Django application using `collectstatic`
+media
+static

--- a/README.md
+++ b/README.md
@@ -66,13 +66,3 @@ Training can be performed with the following steps:
 python graph_parser.py  --train_file TRAINFILE --dev_file DEVFILE  params.yaml
 ```
 after some time (minutes,hours,days...) you are done and the model is ready to run (go back to the parsing section)
-
-  
-
-
-
-
-
-
-
-

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 fasttext
 torch
 transformers
+yaml

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+fasttext
+torch
+transformers

--- a/src/lexers.py
+++ b/src/lexers.py
@@ -2,7 +2,7 @@ import torch
 import fasttext
 from torch import nn
 from graph_parser2 import DependencyDataset,DepGraph
-from transformers  import AutoModel, AutoTokenizer
+from transformers  import AutoConfig, AutoModel, AutoTokenizer
 from collections   import Counter,defaultdict
 from random import random
 
@@ -120,7 +120,8 @@ class BertBaseLexer(nn.Module):
         
         self.embedding              = nn.Embedding(len(self.itos), default_embedding_size, padding_idx=DependencyDataset.PAD_IDX)
         
-        self.bert,_                 = AutoModel.from_pretrained(bert_modelfile, output_loading_info=True, output_hidden_states=True)
+        bert_config                 = AutoConfig.from_pretrained(bert_modelfile, output_hidden_states=True)
+        self.bert                   = AutoModel.from_pretrained(bert_modelfile, config=bert_config)
         self.bert_tokenizer         = AutoTokenizer.from_pretrained(bert_modelfile,
                                                                     to_lowercase_and_remove_accent=False,
                                                                     unk_token=DependencyDataset.UNK_WORD,

--- a/src/lexers.py
+++ b/src/lexers.py
@@ -2,9 +2,7 @@ import torch
 import fasttext
 from torch import nn
 from graph_parser2 import DependencyDataset,DepGraph
-from transformers  import BertModel, BertTokenizer
-from transformers  import FlaubertModel, FlaubertTokenizer
-from transformers  import CamembertModel,CamembertTokenizer
+from transformers  import AutoModel, AutoTokenizer
 from collections   import Counter,defaultdict
 from random import random
 
@@ -122,24 +120,11 @@ class BertBaseLexer(nn.Module):
         
         self.embedding              = nn.Embedding(len(self.itos), default_embedding_size, padding_idx=DependencyDataset.PAD_IDX)
         
-        if bert_modelfile.startswith('flaubert'):
-            self.bert,_                 = FlaubertModel.from_pretrained(bert_modelfile, output_loading_info=True, output_hidden_states=True)
-            self.bert_tokenizer         = FlaubertTokenizer.from_pretrained(bert_modelfile,\
-                                                                       do_lowercase_and_remove_accent=False,\
-                                                                       unk_token=DependencyDataset.UNK_WORD,\
-                                                                       pad_token=DependencyDataset.PAD_TOKEN)
-                                                                       
-        elif bert_modelfile.startswith('bert'):
-            self.bert,_                 = BertModel.from_pretrained(bert_modelfile, output_loading_info=True, output_hidden_states=True)
-            self.bert_tokenizer         = BertTokenizer.from_pretrained(bert_modelfile,\
-                                                                        do_lowercase_and_remove_accent=False)
-                                                                        
-        elif bert_modelfile.startswith('camembert'):
-            self.bert,_                 = CamembertModel.from_pretrained(bert_modelfile, output_loading_info=True, output_hidden_states=True)
-            self.bert_tokenizer         = CamembertTokenizer.from_pretrained(bert_modelfile,\
-                                                                       do_lowercase_and_remove_accent=False,\
-                                                                       unk_token=DependencyDataset.UNK_WORD,\
-                                                                       pad_token=DependencyDataset.PAD_TOKEN)
+        self.bert,_                 = AutoModel.from_pretrained(bert_modelfile, output_loading_info=True, output_hidden_states=True)
+        self.bert_tokenizer         = AutoTokenizer.from_pretrained(bert_modelfile,
+                                                                    to_lowercase_and_remove_accent=False,
+                                                                    unk_token=DependencyDataset.UNK_WORD,
+                                                                    pad_token=DependencyDataset.PAD_TOKEN)
                                                                        
         
         self.BERT_PAD_IDX = self.bert_tokenizer.pad_token_id


### PR DESCRIPTION
Instead of hardcoding the lexers, allow for anything that `transformers.AutoModel` can use. This allows an easier loading of custom models.

@bencrabbe j'ai fait quelques tests vite fait en local et ça marche mais il vaut peut-être mieux que tu regarde si ça casse pas tes expés :-) tu me dis et si ça te va, je merge