### PR TITLE
Improve configurations

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@ French, but it might be trained for other languages without difficulties.
 
 ## Installation
 
-The parser is known to work with python >= 3.7. Install with pip, which should take care of all the dependencies and install the `graph_parser`
-console entry point
+The parser is known to work with python >= 3.7. Install with pip, which should take care of all the
+dependencies and install the `graph_parser` console entry point
 
 ```sh
 pip install git+https://github.com/bencrabbe/npdependency
@@ -35,8 +35,7 @@ in `setup.cfg` and call `python -m npdependency.graph_parser3` directly from the
 ## Parsing task
 
 The parsing task (or prediction task) assumes you have an already trained model in the directory
-MODEL. You can parse a file FILE in truncated CONLL-U format with the
-command:
+MODEL. You can parse a file FILE in truncated CONLL-U format with the command:
 
 ```sh
 graph_parser  --pred_file FILE   MODEL/params.yaml
@@ -45,7 +44,9 @@ graph_parser  --pred_file FILE   MODEL/params.yaml
 This results in a parsed file called `FILE.parsed`. The `MODEL/params.yaml` is the model
 hyperparameters file. An example model is stored in the `default` directory. The file
 `default/params.yaml` is an example of such parameter file. The `FILE` argument is supposed to be
-formatted in truncated [CONLL-U](https://universaldependencies.org/format.html) format. For instance:
+formatted in truncated [CONLL-U](https://universaldependencies.org/format.html) format. For
+instance:
+
 ```
 1       Flaubert
 2       a
@@ -54,9 +55,9 @@ formatted in truncated [CONLL-U](https://universaldependencies.org/format.html) 
 5       Bovary
 6       .
 ```
+
 That is we require word indexation and word forms only. Empty words are currently not supported.
 Multi-word tokens are not taken into account by the parsing models.
-
 
 We advise to use the `flaubert` model which is stored in the flaubert directory. Depending on the
 model, the parser will be more or less fast and more or less accurate. We can however expect the
@@ -67,14 +68,14 @@ provides an option for controlling the GPU actually used for performing computat
 
 We provide some pretrained models:
 
-| Model name         | Language   | device  | LAS  | speed   | Comment                                 | Download link                                                                                            |
-| ------------------ | ---------- | ------- | ---- | ------- | --------------------------------------- | -------------------------------------------------------------------------------------------------------- |
-| ftb_default        | French     | GPU/CPU | 85.9 | fast    | French treebank + fasttext              | [download model](http://www.linguist.univ-paris-diderot.fr/~bcrabbe/depmodels/ftb_default.tar.gz)        |
-| ftb_flaubert       | French     | GPU     | 88.3 | average | FlaubertBase+French treebank + fasttext | [download model](http://www.linguist.univ-paris-diderot.fr/~bcrabbe/depmodels/ftb_flaubert.tar.gz)       |
-| ftb_camembert      | French     | GPU     | 87.9 | average | camembert+French treebank + fasttext    | [download model](http://www.linguist.univ-paris-diderot.fr/~bcrabbe/depmodels/ftb_camembert.tar.gz)      |
-| ud_fr_gsd_default  | French     | GPU/CPU | 90.2 | fast    | UD French GSD + fasttext                | [download model](http://www.linguist.univ-paris-diderot.fr/~bcrabbe/depmodels/fr_gsd_default.tar.gz)     |
-| ud_fr_gsd_flaubert | French     | GPU     | 92.4 | average | FlaubertBase + UD French GSD + fasttext | [download model](http://www.linguist.univ-paris-diderot.fr/~bcrabbe/depmodels/ud_fr_gsd_flaubert.tar.gz) |
-| ud_fro_default     | Old French | GPU/CPU | 85.9 | fast    | SRCMF treebank + fasttext               | [download model](http://www.linguist.univ-paris-diderot.fr/~bcrabbe/depmodels/ud_of_default.tar.gz)      |
+| Model name         | Language   | device  | LAS  | speed   | Comment                                 | Download link                                                                                                     |
+| ------------------ | ---------- | ------- | ---- | ------- | --------------------------------------- | ----------------------------------------------------------------------------------------------------------------- |
+| ftb_default        | French     | GPU/CPU | 85.9 | fast    | French treebank + fasttext              | [download model](https://github.com/bencrabbe/npdependency/releases/download/v0.1.0dev0/ftb_default.tar.gz)       |
+| ftb_flaubert       | French     | GPU     | 88.3 | average | FlaubertBase+French treebank + fasttext | [download model](https://sharedocs.huma-num.fr/wl/?id=fVAdiTHwZhVeqrscNTMXehxsNJtBx9Zc)                           |
+| ftb_camembert      | French     | GPU     | 87.9 | average | camembert+French treebank + fasttext    | [download model](https://sharedocs.huma-num.fr/wl/?id=r0H0HESGOawmWiRxSqXDARC81TiGDBwW)                           |
+| ud_fr_gsd_default  | French     | GPU/CPU | 90.2 | fast    | UD French GSD + fasttext                | [download model](https://github.com/bencrabbe/npdependency/releases/download/v0.1.0dev0/fr_gsd_default.tar.gz)    |
+| ud_fr_gsd_flaubert | French     | GPU     | 92.4 | average | FlaubertBase + UD French GSD + fasttext | [download model](https://sharedocs.huma-num.fr/wl/?id=zWyaLI0xUkogeMFn9MoiVPjKPeDOzDW0)                           |
+| ud_fro_default     | Old French | GPU/CPU | 85.9 | fast    | SRCMF treebank + fasttext               | [download model](https://github.com/bencrabbe/npdependency/releases/download/v0.1.0dev0/fro_srcmf_default.tar.gz) |
 
 The reader may notice a difference with the results published in
 [(Le et al 2020)](https://arxiv.org/abs/1912.05372). The difference comes from a better usage of
@@ -100,6 +101,6 @@ Training can be performed with the following steps:
 ```sh
 graph_parser  --train_file TRAINFILE --dev_file DEVFILE  params.yaml
 ```
-where TRAINFILE and DEVFILE are given in CONLL-U format (without empty words).
-After some time (minutes, hours ...) you are done and the model is ready to run (go back to the
-parsing section)
+
+where TRAINFILE and DEVFILE are given in CONLL-U format (without empty words). After some time
+(minutes, hours ...) you are done and the model is ready to run (go back to the parsing section)

--- a/npdependency/graph_parser.py
+++ b/npdependency/graph_parser.py
@@ -145,8 +145,7 @@ class BiAffineParser(nn.Module):
         torch.save(self.state_dict(), path)
 
     def load_params(self, path):
-
-        self.load_state_dict(torch.load(path))
+        self.load_state_dict(torch.load(path, map_location=self.device))
         self.eval()
 
     def forward(self, xwords, xchars, xft):

--- a/npdependency/graph_parser.py
+++ b/npdependency/graph_parser.py
@@ -650,6 +650,9 @@ def main():
     else:
         model_dir = os.path.dirname(config_file)
 
+    with open(config_file) as in_stream:
+            hp = yaml.load(in_stream, Loader=yaml.SafeLoader)
+
     if args.train_file and args.dev_file:
         # TRAIN MODE
         weights_file = os.path.join(model_dir, "model.pt")
@@ -725,9 +728,6 @@ def main():
             use_labels=parser.labels,
             use_tags=parser.tagset,
         )
-
-        with open(config_file) as in_stream:
-            hp = yaml.load(in_stream, Loader=yaml.SafeLoader)
 
         parser.train_model(
             trainset,

--- a/npdependency/graph_parser.py
+++ b/npdependency/graph_parser.py
@@ -587,10 +587,7 @@ def main():
                 ordered_vocab, hp["word_embedding_size"], hp["word_dropout"]
             )
         else:
-            if "cased" in hp:
-                cased = True
-            else:
-                cased = "uncased" not in bert_modelfile
+            cased = hp.get("cased", "uncased" not in bert_modelfile)
             lexer = BertBaseLexer(
                 ordered_vocab,
                 hp["word_embedding_size"],
@@ -682,10 +679,7 @@ def main():
                 ordered_vocab, hp["word_embedding_size"], hp["word_dropout"]
             )
         else:
-            if "cased" in hp:
-                cased = True
-            else:
-                cased = "uncased" not in bert_modelfile
+            cased = hp.get("cased", "uncased" not in bert_modelfile)
             lexer = BertBaseLexer(
                 ordered_vocab,
                 hp["word_embedding_size"],

--- a/npdependency/graph_parser.py
+++ b/npdependency/graph_parser.py
@@ -149,7 +149,6 @@ class BiAffineParser(nn.Module):
 
     def load_params(self, path):
         self.load_state_dict(torch.load(path, map_location=self.device))
-        self.eval()
 
     def forward(self, xwords, xchars, xft):
         """Computes char embeddings"""
@@ -707,6 +706,7 @@ def main():
         print("training done.", file=sys.stderr)
         # Load final params
         parser.load_params(os.path.join(MODEL_DIR, f"{bert_modelfile}-model.pt"))
+        parser.eval()
         if args.out_dir is not None:
             parsed_devset_path = os.path.join(
                 args.out_dir, f"{os.path.basename(args.dev_file)}.parsed"
@@ -729,6 +729,7 @@ def main():
     if args.pred_file:
         # TEST MODE
         parser = BiAffineParser.from_config(args.config_file)
+        parser.eval()
         testtrees = DependencyDataset.read_conll(args.pred_file)
         ft_dataset = FastTextDataSet(parser.ft_lexer)
         testset = DependencyDataset(

--- a/npdependency/graph_parser.py
+++ b/npdependency/graph_parser.py
@@ -629,7 +629,7 @@ def main():
     )
 
     args = parser.parse_args()
-    hp = yaml.load(open(args.config_file).read(), Loader=yaml.FullLoader)
+    hp = yaml.load(open(args.config_file).read(), Loader=yaml.SafeLoader)
     if args.device is not None:
         hp["device"] = args.device
 

--- a/npdependency/graph_parser.py
+++ b/npdependency/graph_parser.py
@@ -533,7 +533,7 @@ class BiAffineParser(nn.Module):
             hp["mlp_lab_hidden"],
             hp["mlp_dropout"],
             itolab,
-            hp["device"],
+            hp.get("device", "cpu"),
         )
         weights_file = config_dir / "model.pt"
         if weights_file.exists():

--- a/npdependency/graph_parser.py
+++ b/npdependency/graph_parser.py
@@ -617,6 +617,12 @@ def main():
         help="the path of the output directory (defaults to the config dir)",
     )
     parser.add_argument(
+        "--device",
+        metavar="DEVICE",
+        type=str,
+        help="the (torch) device to use for the parser. Supersedes configuration if given",
+    )
+    parser.add_argument(
         "--overwrite",
         action="store_true",
         help="If a model already exists, restart training from scratch instead of continuing.",
@@ -624,6 +630,8 @@ def main():
 
     args = parser.parse_args()
     hp = yaml.load(open(args.config_file).read(), Loader=yaml.FullLoader)
+    if args.device is not None:
+        hp["device"] = args.device
 
     config_file = os.path.abspath(args.config_file)
     if args.out_dir:
@@ -670,6 +678,7 @@ def main():
             savelist(itotag, os.path.join(model_dir, "tagcodes.lst"))
 
         parser = BiAffineParser.from_config(config_file)
+        parser.to(hp.get("device", "cpu"))
 
         ft_dataset = FastTextDataSet(parser.ft_lexer)
         trainset = DependencyDataset(


### PR DESCRIPTION
This is an attempt at simplifying how the models and configuration work, making some things more explicit and adding some new options.

**Note** There is a slight breaking change here: model subfiles have to be renamed for old models to work so the currently provided models should be repackaged. ~~It should probably be done before merging this but I can do it. Also according to [GitHub doc](https://docs.github.com/en/free-pro-team@latest/github/managing-large-files/distributing-large-binaries), we can upload files up to 2 GiB in releases, so at least the non-BERT models could go there, and the others either on Sharedoc or Zenodo if they are too large.~~ 

The repackaged non-BERT models have been uploaded to [a pre-release](https://github.com/bencrabbe/npdependency/releases/tag/v0.1.0dev0) that serves as on-GitHub hosting. The BERT models are slightly over 2GiB/file so they couldn't be put there. As a temporary solution, I have put them in [a public directory](https://sharedocs.huma-num.fr/wl/?id=Kh5C5FFdhMInTWgUQwLnWof9fXDlM4al) on HumaNum's Sharedoc. Models for a stable release should probably go to Zenodo, where they can get a DOI and are more easily cited.

## Added

### CLI

- **Breaking** An `--overwrite` argument to force retraining the model from scratch if one is already present in the target directory
- A `--fasttext` argument to `graph_parser` that can take either the path to a pretrained FastText model or the path to a raw text file to generate a model from.
- A `--device` argument, to override the device specified in a model configuration
- More explicit logging of what is done with FastText models at train time, and in particular whether the model is loaded or trained and the path to the source files

### Models

- Configs now accept a `cased` parameter to indicate whether a BERT lexer should be cased. If this parameter is absent, this choice defaults to `cased`, unless the BERT model has `uncased` in its name (the previous behaviour).

### API

- A new classmethod `graph_parser.BiaffineParser.from_config` that wraps the whole process of creating a `BiaffineParser` from a config directory with a config file and all the vocabulary and auxiliary models (but possibly lacking the weights).
- Two new functions `deptree.gen_tags` and `deptree.gen_labels` to generate tags and labels vocabularies without having to create a full `DependencyDataset`
- A new class method `lexers.FastTextTorch.train_model_from_raw`, a simple wrapper for `fasttext.train_unsupervised`

## Changed

### CLI

- **Breaking** When `--overwrite` is not provided and a trained model already exists in the destination directory, training continues from its state instead of starting from scratch
- Model trained on a device can now be loaded on another device if their `device` config parameter is changed or when asked using `--device`

### Models

- **Breaking** Model subfiles (apart from the config file) now use static names (like `charcodes.lst`), to simplify model saving and loading, the assumption being that since these files are tied to a specific model directory anyway, they don't need custom names. Old models can still be used by simply renaming their subfiles.
- Model configurations can now omit the `device` parameter, which then defaults to `cpu`

### API

- `lexers.FastTextTorch.train_model` has been renamed to `lexers.FastTextTorch.train_model_from_trees` and now throws an error if the destination files already exists instead of silently loading.

### Misc

- Model initialization and loading now both use  `graph_parser.BiaffineParser.from_config` to avoid error-prone code duplication.
- Config files are now loaded with the pyyaml `SafeLoader`, since we do not actually need more than that for now.