### PR TITLE
Configurable BERT layer reduction and lexer improvements

### DIFF
--- a/npdependency/deptree.py
+++ b/npdependency/deptree.py
@@ -1,6 +1,5 @@
 from typing import Iterable, List
 import torch
-from torch.autograd import Variable
 from random import shuffle
 
 
@@ -376,8 +375,8 @@ class DependencyDataset:
                 padded_batchA.append(paddedA)
                 padded_batchB.append(paddedB)
             return (
-                Variable(torch.LongTensor(padded_batchA)),
-                Variable(torch.LongTensor(padded_batchB)),
+                torch.tensor(padded_batchA, dtype=torch.long),
+                torch.tensor(padded_batchB, dtype=torch.long),
             )
         else:
             sent_lengths = list(map(len, batch))
@@ -386,7 +385,7 @@ class DependencyDataset:
             for k, seq in zip(sent_lengths, batch):
                 padded = seq + (max_len - k) * [DependencyDataset.PAD_IDX]
                 padded_batch.append(padded)
-        return Variable(torch.LongTensor(padded_batch))
+        return torch.tensor(padded_batch, dtype=torch.long)
 
     def init_labels(self, treelist: Iterable[DepGraph]):
         self.itolab = gen_labels(treelist)

--- a/npdependency/deptree.py
+++ b/npdependency/deptree.py
@@ -361,6 +361,7 @@ class DependencyDataset:
             subwords = self.ft_dataset.batch_sentences(self.words[i : i + batch_size])
             yield (words, mwe, chars, subwords, cats, deps, tags, heads, labels)
 
+    # TODO: make this use torch padding utility instead
     def pad(self, batch):
         if (
             type(batch[0]) == tuple and len(batch[0]) == 2

--- a/npdependency/graph_parser.py
+++ b/npdependency/graph_parser.py
@@ -151,8 +151,9 @@ class BiAffineParser(nn.Module):
         state_dict = torch.load(path, map_location=self.device)
         # Legacy models do not have BERT layer weights, so we inject them here they always use only
         # 4 layers so we don't have to guess the size of the weight vector
-        if hasattr(self.lexer, "layer_weights"):
+        if hasattr(self.lexer, "layers_gamma"):
             state_dict.setdefault("lexer.layer_weights", torch.ones(4, dtype=torch.float))
+            state_dict.setdefault("lexer.layers_gamma", torch.ones(1, dtype=torch.float))
         self.load_state_dict(state_dict)
 
     def forward(self, xwords, xchars, xft):

--- a/npdependency/graph_parser.py
+++ b/npdependency/graph_parser.py
@@ -151,7 +151,8 @@ class BiAffineParser(nn.Module):
         state_dict = torch.load(path, map_location=self.device)
         # Legacy models do not have BERT layer weights, so we inject them here they always use only
         # 4 layers so we don't have to guess the size of the weight vector
-        state_dict.setdefault("lexer.layer_weights", torch.ones(4, dtype=torch.float))
+        if hasattr(self.lexer, "layer_weights"):
+            state_dict.setdefault("lexer.layer_weights", torch.ones(4, dtype=torch.float))
         self.load_state_dict(state_dict)
 
     def forward(self, xwords, xchars, xft):

--- a/npdependency/graph_parser.py
+++ b/npdependency/graph_parser.py
@@ -183,7 +183,6 @@ class BiAffineParser(nn.Module):
         # Note: the accurracy scoring is approximative and cannot be interpreted as an UAS/LAS score !
 
         self.eval()
-        self.lexer.eval_mode()
 
         dev_batches = dev_set.make_batches(
             batch_size, shuffle_batches=True, shuffle_data=True, order_by_length=True
@@ -291,7 +290,6 @@ class BiAffineParser(nn.Module):
         for e in range(epochs):
             TRAIN_LOSS = 0
             BEST_ARC_ACC = 0
-            self.lexer.train_mode()
             train_batches = train_set.make_batches(
                 batch_size,
                 shuffle_batches=True,
@@ -394,14 +392,13 @@ class BiAffineParser(nn.Module):
 
     def predict_batch(self, test_set, ostream, batch_size, greedy=False):
 
-        self.lexer.eval_mode()
+        self.eval()
         test_batches = test_set.make_batches(
             batch_size, shuffle_batches=False, shuffle_data=False, order_by_length=False
         )  # keep natural order here
 
         with torch.no_grad():
             for batch in test_batches:
-                self.eval()
                 words, mwe, chars, subwords, cats, deps, tags, heads, labels = batch
                 if type(deps) == tuple:
                     depsA, depsB = deps

--- a/npdependency/graph_parser.py
+++ b/npdependency/graph_parser.py
@@ -147,8 +147,12 @@ class BiAffineParser(nn.Module):
     def save_params(self, path):
         torch.save(self.state_dict(), path)
 
-    def load_params(self, path):
-        self.load_state_dict(torch.load(path, map_location=self.device))
+    def load_params(self, path: str):
+        state_dict = torch.load(path, map_location=self.device)
+        # Legacy models do not have BERT layer weights, so we inject them here they always use only
+        # 4 layers so we don't have to guess the size of the weight vector
+        state_dict.setdefault("lexer.layer_weights", torch.ones(4, dtype=torch.float))
+        self.load_state_dict(state_dict)
 
     def forward(self, xwords, xchars, xft):
         """Computes char embeddings"""

--- a/npdependency/graph_parser.py
+++ b/npdependency/graph_parser.py
@@ -297,20 +297,18 @@ class BiAffineParser(nn.Module):
                 order_by_length=True,
             )
             overall_size = 0
+            self.train()
             for batch in train_batches:
-                self.train()
                 words, mwe, chars, subwords, cats, deps, tags, heads, labels = batch
                 if type(deps) == tuple:
                     depsA, depsB = deps
                     deps = (depsA.to(self.device), depsB.to(self.device))
-                    overall_size += depsA.size(0) * depsA.size(
-                        1
-                    )  # bc no masking at training
+                    # bc no masking at training
+                    overall_size += depsA.size(0) * depsA.size(1)
                 else:
+                    # bc no masking at training
                     deps = deps.to(self.device)
-                    overall_size += deps.size(0) * deps.size(
-                        1
-                    )  # bc no masking at training
+                    overall_size += deps.size(0) * deps.size(1)
                 heads, labels, tags = (
                     heads.to(self.device),
                     labels.to(self.device),
@@ -504,11 +502,13 @@ class BiAffineParser(nn.Module):
             bert_model_name = hp["lexer"].split("/")[-1]
             cased = hp.get("cased", "uncased" not in bert_model_name)
             lexer = BertBaseLexer(
-                ordered_vocab,
-                hp["word_embedding_size"],
-                hp["word_dropout"],
+                default_itos=ordered_vocab,
+                default_embedding_size=hp["word_embedding_size"],
+                word_dropout=hp["word_dropout"],
                 cased=cased,
                 bert_modelfile=hp["lexer"],
+                bert_layers=hp.get("bert_layers", [4, 5, 6, 7]),
+                bert_weighted=hp.get("bert_weighted", False),
             )
 
         # char rnn processor

--- a/npdependency/lexers.py
+++ b/npdependency/lexers.py
@@ -354,7 +354,6 @@ class BertBaseLexer(nn.Module):
         the embeddings from the last (top) BERT layer.
         """
         word_idxes, bert_idxes = coupled_sequences
-        # bertE                = self.bert(bert_idxes)[0]
         bert_layers = self.bert(bert_idxes)[-1]
         bertE = torch.mean(
             torch.stack(bert_layers[4:8]), 0

--- a/npdependency/lexers.py
+++ b/npdependency/lexers.py
@@ -326,7 +326,6 @@ class BertBaseLexer(nn.Module):
 
         self.BERT_PAD_IDX = self.bert_tokenizer.pad_token_id
         self.BERT_UNK_IDX = self.bert_tokenizer.unk_token_id
-        self.BERT_SIZE = self.bert.config.hidden_size  # incorrect
 
         self.embedding = nn.Embedding(
             len(self.itos),

--- a/npdependency/lexers.py
+++ b/npdependency/lexers.py
@@ -404,7 +404,7 @@ class BertBaseLexer(nn.Module):
             # FIXME: recomputing the softmax for every batch is needed at train time but is wasting
             # time in eval
             # Shape: layers
-            normal_weights = self.layer_weights.softmax()
+            normal_weights = self.layer_weights.softmax(dim=0)
             # shape: batch×sequence×features
             bertE = self.layers_gamma * torch.einsum(
                 "l,lbsf->bsf", normal_weights, selected_bert_layers

--- a/npdependency/lexers.py
+++ b/npdependency/lexers.py
@@ -316,7 +316,6 @@ class BertBaseLexer(nn.Module):
     ):
 
         super(BertBaseLexer, self).__init__()
-        self._embedding_size = default_embedding_size
         self.itos = default_itos
         self.stoi = {token: idx for idx, token in enumerate(self.itos)}
 
@@ -341,14 +340,6 @@ class BertBaseLexer(nn.Module):
         self.word_dropout = word_dropout
         self._dpout = 0.0
         self.cased = cased
-
-    @property
-    def embedding_size(self):
-        return self._embedding_size + self.BERT_SIZE
-
-    @embedding_size.setter
-    def embedding_size(self, value):
-        self._embedding_size = value + self.BERT_SIZE
 
     def train(self, mode: bool = True) -> "BertBaseLexer":
         if mode:

--- a/npdependency/lexers.py
+++ b/npdependency/lexers.py
@@ -321,7 +321,7 @@ class BertBaseLexer(nn.Module):
 
         self.bert = AutoModel.from_pretrained(bert_modelfile, output_hidden_states=True)
         self.bert_tokenizer = AutoTokenizer.from_pretrained(
-            bert_modelfile, to_lowercase_and_remove_accent=False
+            bert_modelfile, use_fast=True
         )
 
         self.BERT_PAD_IDX = self.bert_tokenizer.pad_token_id

--- a/npdependency/lexers.py
+++ b/npdependency/lexers.py
@@ -326,6 +326,7 @@ class BertBaseLexer(nn.Module):
 
         self.BERT_PAD_IDX = self.bert_tokenizer.pad_token_id
         self.BERT_UNK_IDX = self.bert_tokenizer.unk_token_id
+        self.embedding_size = default_embedding_size + self.bert.config.hidden_size
 
         self.embedding = nn.Embedding(
             len(self.itos),

--- a/npdependency/lexers.py
+++ b/npdependency/lexers.py
@@ -363,6 +363,9 @@ class BertBaseLexer(nn.Module):
             padding_idx=DependencyDataset.PAD_IDX,
         )
 
+        # ! FIXME: this is still somewhat brittle, since the BERT models have not been trained with
+        # ! the root token at sentence beginning. Maybe we could use the BOS token for that purpose
+        # ! instead?
         self.bert_tokenizer.add_tokens([DepGraph.ROOT_TOKEN], special_tokens=True)
         self.bert.resize_token_embeddings(len(self.bert_tokenizer))
 

--- a/npdependency/lexers.py
+++ b/npdependency/lexers.py
@@ -401,8 +401,8 @@ class BertBaseLexer(nn.Module):
         )
         if self.bert_weighted:
             # Torch has no equivalent to `np.average` so this is somewhat annoying
-            # FIXME: recomputing the softmax for every batch is needed at train time but is wasting
-            # time in eval
+            # ! FIXME: recomputing the softmax for every batch is needed at train time but is wasting
+            # ! time in eval
             # Shape: layers
             normal_weights = self.layer_weights.softmax(dim=0)
             # shape: batch×sequence×features
@@ -430,19 +430,16 @@ class BertBaseLexer(nn.Module):
         # ? COMBAK: lowercasing should be done by the loaded tokenizer or am I missing something
         # ? here? (2020-11-08)
         if self.cased:
-            bert_idxes = [
-                self.bert_tokenizer.convert_tokens_to_ids(
-                    self.bert_tokenizer.tokenize(token)
-                )[0]
-                for token in tok_sequence
+            bert_tokens = [
+                self.bert_tokenizer.tokenize(token) for token in tok_sequence
             ]
         else:
-            bert_idxes = [
-                self.bert_tokenizer.convert_tokens_to_ids(
-                    self.bert_tokenizer.tokenize(token.lower())
-                )[0]
-                for token in tok_sequence
+            bert_tokens = [
+                self.bert_tokenizer.tokenize(token.lower()) for token in tok_sequence
             ]
+        bert_idxes = [
+            self.bert_tokenizer.convert_tokens_to_ids(token)[0] for token in bert_tokens
+        ]
 
         if self._dpout:
             word_idxes = [

--- a/npdependency/lexers.py
+++ b/npdependency/lexers.py
@@ -374,7 +374,7 @@ class BertBaseLexer(nn.Module):
         # Shape: layers
         normal_weights = self.layer_weights.div(self.layer_weights.sum())
         # shape: batch×sequence×features
-        bertE = torch.einsum("l,lbsf->bsf", normal_weights.matmul, selected_bert_layers)
+        bertE = torch.einsum("l,lbsf->bsf", normal_weights, selected_bert_layers)
         wordE = self.embedding(word_idxes)
         return torch.cat((wordE, bertE), dim=2)
 

--- a/npdependency/lexers.py
+++ b/npdependency/lexers.py
@@ -299,6 +299,33 @@ class DefaultLexer(nn.Module):
         return word_idxes
 
 
+def freeze_module(transformer, freezing: bool = True):
+    """Make a `torch.nn.Module` either finetunable 🔥 or frozen ❄.
+
+    **WARNINGS**
+    
+    - Freezing a module will put it in eval mode (since a frozen module can't be in training mode),
+      but unfreezing it will not put it back in training mode (since an unfrozen module still has an
+      eval mode that you might want to use), you have to do that yourself.
+    - Manually setting the submodules of a frozen module to train is not disabled, but if you want
+      to do that, writing a custom freezing function is probably a better idea
+    """
+
+    # This will replace the transformer train function
+    def no_train(model, mode=True):
+        return model
+
+    if freezing:
+        transformer.eval()
+        transformer.train = no_train
+        for p in transformer.parameters():
+            p.requires_grad = False
+    else:
+        for p in transformer.parameters():
+            p.requires_grad = False
+        transformer.train = type(transformer).train
+
+
 class BertBaseLexer(nn.Module):
     """
     This Lexer performs tokenization and embedding mapping with BERT

--- a/npdependency/lexers.py
+++ b/npdependency/lexers.py
@@ -299,31 +299,31 @@ class DefaultLexer(nn.Module):
         return word_idxes
 
 
-def freeze_module(transformer, freezing: bool = True):
+def freeze_module(module, freezing: bool = True):
     """Make a `torch.nn.Module` either finetunable 🔥 or frozen ❄.
 
     **WARNINGS**
-    
+
     - Freezing a module will put it in eval mode (since a frozen module can't be in training mode),
       but unfreezing it will not put it back in training mode (since an unfrozen module still has an
       eval mode that you might want to use), you have to do that yourself.
     - Manually setting the submodules of a frozen module to train is not disabled, but if you want
-      to do that, writing a custom freezing function is probably a better idea
+      to do that, writing a custom freezing function is probably a better idea.
     """
 
-    # This will replace the transformer train function
+    # This will replace the module's train function when freezing
     def no_train(model, mode=True):
         return model
 
     if freezing:
-        transformer.eval()
-        transformer.train = no_train
-        for p in transformer.parameters():
+        module.eval()
+        module.train = no_train
+        for p in module.parameters():
             p.requires_grad = False
     else:
-        for p in transformer.parameters():
-            p.requires_grad = False
-        transformer.train = type(transformer).train
+        for p in module.parameters():
+            p.requires_grad = True
+        module.train = type(module).train
 
 
 class BertBaseLexer(nn.Module):


### PR DESCRIPTION
This PR addresses #6, and brings with it some other improvements. As a hint of the influence of these changes, for Old French parsing, using mBERT and no pretrained FastText gives the following scores with the new settings

| Layers | Weigted | Frozen | UPOS_F | UAS_F  | LAS_F  | 
|--------|---------|--------|--------|--------|--------| 
| 4..8   | no      | no     | 93.83% | 88.49% | 82.56% | 
| 0..12  | no      | no     | 94.21% | 89.06% | 83.41% | 
| 0..12  | yes     | no     | 94.20% | 88.95% | 83.17% | 
| 0..12  | yes     | yes    | 94.53% | 89.37% | 83.75% | 

This is of course by no mean exhaustive testing, for which I think we should wait until #11 is addressed.

## Added

### Configs

- A new config option `bert_layers` that takes a list of integers to choose the layers to take into account when using a BERT model (defaults to the former behaviour `[4, 5, 6, 7]` when not provided, for backward compatibiliy).
- A new config option `bert_weighting` that takes a boolean. When it is false or absent, BERT word embeddings are averaged across the selected layers without weights (the former behaviour). When it is true, the average will be weighted with an ELMo-like scheme: if eᵢ is the embedding at the i-th layer, the final token embedding e will be e=γ∑ᵢwᵢeᵢ, with (wᵢ)=softmax(αᵢ), where γ and the αᵢ are trainable parameters of the lexer.
- A new config option `freeze_bert` that takes a boolean, which when true signals that the weights of the BERT model will not be trained and that it will be kept in eval state (e.g. without dropout) when we train the parser, thus only providing frozen representations (if using `bert_weighting`, the averaging weights of the lexer are still trained.

### Misc.

- A small utility function `lexers.freeze_module` that locks any `torch.nn.Module` in `eval` state for all intent and purposes. It lives in lexer for now since it's only used to freeze BERT models, but it might be useful at some other points.

## Changed

- Lexers now use the standard `train` and `eval` functions of `torch.nn.Module` instead of their custom `train_mode` and `eval_mode`, so they now automatically change their training state when the parent parser does.
- The ROOT token is now added as a special token for BERT tokenizers instead of a regular token (although we will probably have to revisit that while addressing #11)