### PR TITLE
Lexers improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,8 @@ We provide some pretrained models:
 | ftb_flaubert       | French     | GPU     | 88.3 | average | FlaubertBase+French treebank + fasttext | [download model](https://sharedocs.huma-num.fr/wl/?id=fVAdiTHwZhVeqrscNTMXehxsNJtBx9Zc)                           |
 | ftb_camembert      | French     | GPU     | 87.9 | average | camembert+French treebank + fasttext    | [download model](https://sharedocs.huma-num.fr/wl/?id=r0H0HESGOawmWiRxSqXDARC81TiGDBwW)                           |
 | ud_fr_gsd_default  | French     | GPU/CPU | 90.2 | fast    | UD French GSD + fasttext                | [download model](https://github.com/bencrabbe/npdependency/releases/download/v0.1.0dev0/fr_gsd_default.tar.gz)    |
-| ud_fr_gsd_flaubert | French     | GPU     | 92.4 | average | FlaubertBase + UD French GSD + fasttext | [download model](https://sharedocs.huma-num.fr/wl/?id=zWyaLI0xUkogeMFn9MoiVPjKPeDOzDW0)                           |
+| ud_fr_gsd_flaubert | French     | GPU     | 92.4 | average | flaubert_base_cased + UD French GSD + fasttext | [download model](https://sharedocs.huma-num.fr/wl/?id=sAARm9xFNdITZArRYn2qF9UUTj0KqBtu)                           |
+| ud_fr_gsd_camembert | French     | GPU     | 92.4 | average | camembert-base + UD French GSD + fasttext | [download model](https://sharedocs.huma-num.fr/wl/?id=DrKZLgdikOI5TZoVLfcykRLEmUUyLoBN)                           |
 | ud_fro_default     | Old French | GPU/CPU | 85.9 | fast    | SRCMF treebank + fasttext               | [download model](https://github.com/bencrabbe/npdependency/releases/download/v0.1.0dev0/fro_srcmf_default.tar.gz) |
 
 The reader may notice a difference with the results published in

--- a/README.md
+++ b/README.md
@@ -76,7 +76,6 @@ We provide some pretrained models:
 | ud_fr_gsd_default   | French     | GPU/CPU | 91.98     | 88.96      | fast    | UD French GSD 2.6 + fasttext                       | [download model](https://github.com/bencrabbe/npdependency/releases/download/v0.2.0dev0/ud_fr_gsd_default.tar.gz) |
 | ud_fr_gsd_flaubert  | French     | GPU     | 95.06     | 93.77      | average | flaubert_base_cased + UD French GSD 2.6 + fasttext | [download model](https://sharedocs.huma-num.fr/wl/?id=sAARm9xFNdITZArRYn2qF9UUTj0KqBtu)                           |
 | ud_fr_gsd_camembert | French     | GPU     | 95.06     | 93.28      | average | camembert-base + UD French GSD 2.6 + fasttext      | [download model](https://sharedocs.huma-num.fr/wl/?id=DrKZLgdikOI5TZoVLfcykRLEmUUyLoBN)                           |
-| ud_fro_default      | Old French | GPU/CPU |           | 85.9       | fast    | SRCMF treebank + fasttext                          | [download model](https://github.com/bencrabbe/npdependency/releases/download/v0.1.0dev0/fro_srcmf_default.tar.gz) |
 
 The reader may notice a difference with the results published in
 [(Le et al 2020)](https://arxiv.org/abs/1912.05372). The difference comes from a better usage of

--- a/README.md
+++ b/README.md
@@ -68,15 +68,15 @@ provides an option for controlling the GPU actually used for performing computat
 
 We provide some pretrained models:
 
-| Model name          | Language   | device  | LAS   | speed   | Comment                                        | Download link                                                                                                     |
-| ------------------- | ---------- | ------- | ----- | ------- | ---------------------------------------------- | ----------------------------------------------------------------------------------------------------------------- |
-| ftb_default         | French     | GPU/CPU | 85.9  | fast    | French treebank + fasttext                     | [download model](https://github.com/bencrabbe/npdependency/releases/download/v0.1.0dev0/ftb_default.tar.gz)       |
-| ftb_flaubert        | French     | GPU     | 88.3  | average | FlaubertBase+French treebank + fasttext        | [download model](https://sharedocs.huma-num.fr/wl/?id=fVAdiTHwZhVeqrscNTMXehxsNJtBx9Zc)                           |
-| ftb_camembert       | French     | GPU     | 87.9  | average | camembert+French treebank + fasttext           | [download model](https://sharedocs.huma-num.fr/wl/?id=r0H0HESGOawmWiRxSqXDARC81TiGDBwW)                           |
-| ud_fr_gsd_default   | French     | GPU/CPU | 88.96 | fast    | UD French GSD + fasttext                       | [download model](https://github.com/bencrabbe/npdependency/releases/download/v0.2.0dev0/ud_fr_gsd_default.tar.gz) |
-| ud_fr_gsd_flaubert  | French     | GPU     | 93.77 | average | flaubert_base_cased + UD French GSD + fasttext | [download model](https://sharedocs.huma-num.fr/wl/?id=sAARm9xFNdITZArRYn2qF9UUTj0KqBtu)                           |
-| ud_fr_gsd_camembert | French     | GPU     | 93.28 | average | camembert-base + UD French GSD + fasttext      | [download model](https://sharedocs.huma-num.fr/wl/?id=DrKZLgdikOI5TZoVLfcykRLEmUUyLoBN)                           |
-| ud_fro_default      | Old French | GPU/CPU | 85.9  | fast    | SRCMF treebank + fasttext                      | [download model](https://github.com/bencrabbe/npdependency/releases/download/v0.1.0dev0/fro_srcmf_default.tar.gz) |
+| Model name          | Language   | device  | LAS (dev) | LAS (test) | speed   | Comment                                            | Download link                                                                                                     |
+| ------------------- | ---------- | ------- | --------- | ---------- | ------- | -------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------- |
+| ftb_default         | French     | GPU/CPU |           | 85.9       | fast    | French treebank + fasttext                         | [download model](https://github.com/bencrabbe/npdependency/releases/download/v0.1.0dev0/ftb_default.tar.gz)       |
+| ftb_flaubert        | French     | GPU     |           | 88.3       | average | FlaubertBase+French treebank + fasttext            | [download model](https://sharedocs.huma-num.fr/wl/?id=fVAdiTHwZhVeqrscNTMXehxsNJtBx9Zc)                           |
+| ftb_camembert       | French     | GPU     |           | 87.9       | average | camembert+French treebank + fasttext               | [download model](https://sharedocs.huma-num.fr/wl/?id=r0H0HESGOawmWiRxSqXDARC81TiGDBwW)                           |
+| ud_fr_gsd_default   | French     | GPU/CPU | 91.98     | 88.96      | fast    | UD French GSD 2.6 + fasttext                       | [download model](https://github.com/bencrabbe/npdependency/releases/download/v0.2.0dev0/ud_fr_gsd_default.tar.gz) |
+| ud_fr_gsd_flaubert  | French     | GPU     | 95.06     | 93.77      | average | flaubert_base_cased + UD French GSD 2.6 + fasttext | [download model](https://sharedocs.huma-num.fr/wl/?id=sAARm9xFNdITZArRYn2qF9UUTj0KqBtu)                           |
+| ud_fr_gsd_camembert | French     | GPU     | 95.06     | 93.28      | average | camembert-base + UD French GSD 2.6 + fasttext      | [download model](https://sharedocs.huma-num.fr/wl/?id=DrKZLgdikOI5TZoVLfcykRLEmUUyLoBN)                           |
+| ud_fro_default      | Old French | GPU/CPU |           | 85.9       | fast    | SRCMF treebank + fasttext                          | [download model](https://github.com/bencrabbe/npdependency/releases/download/v0.1.0dev0/fro_srcmf_default.tar.gz) |
 
 The reader may notice a difference with the results published in
 [(Le et al 2020)](https://arxiv.org/abs/1912.05372). The difference comes from a better usage of

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ hyperparameters file. An example model is stored in the `default` directory. The
 formatted in truncated [CONLL-U](https://universaldependencies.org/format.html) format. For
 instance:
 
-```
+```conllu
 1       Flaubert
 2       a
 3       écrit
@@ -68,15 +68,15 @@ provides an option for controlling the GPU actually used for performing computat
 
 We provide some pretrained models:
 
-| Model name         | Language   | device  | LAS  | speed   | Comment                                 | Download link                                                                                                     |
-| ------------------ | ---------- | ------- | ---- | ------- | --------------------------------------- | ----------------------------------------------------------------------------------------------------------------- |
-| ftb_default        | French     | GPU/CPU | 85.9 | fast    | French treebank + fasttext              | [download model](https://github.com/bencrabbe/npdependency/releases/download/v0.1.0dev0/ftb_default.tar.gz)       |
-| ftb_flaubert       | French     | GPU     | 88.3 | average | FlaubertBase+French treebank + fasttext | [download model](https://sharedocs.huma-num.fr/wl/?id=fVAdiTHwZhVeqrscNTMXehxsNJtBx9Zc)                           |
-| ftb_camembert      | French     | GPU     | 87.9 | average | camembert+French treebank + fasttext    | [download model](https://sharedocs.huma-num.fr/wl/?id=r0H0HESGOawmWiRxSqXDARC81TiGDBwW)                           |
-| ud_fr_gsd_default  | French     | GPU/CPU | 90.2 | fast    | UD French GSD + fasttext                | [download model](https://github.com/bencrabbe/npdependency/releases/download/v0.1.0dev0/fr_gsd_default.tar.gz)    |
-| ud_fr_gsd_flaubert | French     | GPU     | 92.4 | average | flaubert_base_cased + UD French GSD + fasttext | [download model](https://sharedocs.huma-num.fr/wl/?id=sAARm9xFNdITZArRYn2qF9UUTj0KqBtu)                           |
-| ud_fr_gsd_camembert | French     | GPU     | 92.4 | average | camembert-base + UD French GSD + fasttext | [download model](https://sharedocs.huma-num.fr/wl/?id=DrKZLgdikOI5TZoVLfcykRLEmUUyLoBN)                           |
-| ud_fro_default     | Old French | GPU/CPU | 85.9 | fast    | SRCMF treebank + fasttext               | [download model](https://github.com/bencrabbe/npdependency/releases/download/v0.1.0dev0/fro_srcmf_default.tar.gz) |
+| Model name          | Language   | device  | LAS   | speed   | Comment                                        | Download link                                                                                                     |
+| ------------------- | ---------- | ------- | ----- | ------- | ---------------------------------------------- | ----------------------------------------------------------------------------------------------------------------- |
+| ftb_default         | French     | GPU/CPU | 85.9  | fast    | French treebank + fasttext                     | [download model](https://github.com/bencrabbe/npdependency/releases/download/v0.1.0dev0/ftb_default.tar.gz)       |
+| ftb_flaubert        | French     | GPU     | 88.3  | average | FlaubertBase+French treebank + fasttext        | [download model](https://sharedocs.huma-num.fr/wl/?id=fVAdiTHwZhVeqrscNTMXehxsNJtBx9Zc)                           |
+| ftb_camembert       | French     | GPU     | 87.9  | average | camembert+French treebank + fasttext           | [download model](https://sharedocs.huma-num.fr/wl/?id=r0H0HESGOawmWiRxSqXDARC81TiGDBwW)                           |
+| ud_fr_gsd_default   | French     | GPU/CPU | 88.96 | fast    | UD French GSD + fasttext                       | [download model](https://github.com/bencrabbe/npdependency/releases/download/v0.2.0dev0/ud_fr_gsd_default.tar.gz) |
+| ud_fr_gsd_flaubert  | French     | GPU     | 93.77 | average | flaubert_base_cased + UD French GSD + fasttext | [download model](https://sharedocs.huma-num.fr/wl/?id=sAARm9xFNdITZArRYn2qF9UUTj0KqBtu)                           |
+| ud_fr_gsd_camembert | French     | GPU     | 93.28 | average | camembert-base + UD French GSD + fasttext      | [download model](https://sharedocs.huma-num.fr/wl/?id=DrKZLgdikOI5TZoVLfcykRLEmUUyLoBN)                           |
+| ud_fro_default      | Old French | GPU/CPU | 85.9  | fast    | SRCMF treebank + fasttext                      | [download model](https://github.com/bencrabbe/npdependency/releases/download/v0.1.0dev0/fro_srcmf_default.tar.gz) |
 
 The reader may notice a difference with the results published in
 [(Le et al 2020)](https://arxiv.org/abs/1912.05372). The difference comes from a better usage of

--- a/npdependency/deptree.py
+++ b/npdependency/deptree.py
@@ -153,7 +153,7 @@ class DepGraph:
         return self.gap_degree() == 0
 
     @classmethod
-    def read_tree(cls, istream: TextIO) -> "DepGraph":
+    def read_tree(cls, istream: TextIO) -> Optional["DepGraph"]:
         """
         Reads a conll tree from input stream
         """
@@ -174,7 +174,7 @@ class DepGraph:
         for dataline in conll:
             if len(dataline) < 10:  # pads the dataline
                 dataline.extend(["-"] * (10 - len(dataline)))
-                dataline[6] = 0
+                dataline[6] = "0"
 
             if "-" in dataline[0]:
                 mwe_ranges.append(dataline[0].split("-") + [dataline[1]])

--- a/npdependency/deptree.py
+++ b/npdependency/deptree.py
@@ -5,6 +5,8 @@ from typing import Iterable, List, Union
 import torch
 from torch.nn.utils.rnn import pad_sequence
 
+from npdependency import lexers
+
 
 class DepGraph:
 
@@ -244,16 +246,18 @@ class DependencyDataset:
                 if len(tree.words) <= 150:
                     treelist.append(tree)
                 else:
-                    print(f"Dropped tree with length {len(tree.words)} > 150", )
+                    print(
+                        f"Dropped tree with length {len(tree.words)} > 150",
+                    )
                 tree = DepGraph.read_tree(istream)
         return treelist
 
     def __init__(
         self,
-        treelist,
-        lexer,
-        char_dataset,
-        ft_dataset,
+        treelist: List[DepGraph],
+        lexer: lexers.Lexer,
+        char_dataset: lexers.CharDataSet,
+        ft_dataset: lexers.FastTextDataSet,
         use_labels=None,
         use_tags=None,
     ):
@@ -340,10 +344,10 @@ class DependencyDataset:
 
     def make_batches(
         self,
-        batch_size,
-        shuffle_batches=False,
-        shuffle_data=True,
-        order_by_length=False,
+        batch_size: int,
+        shuffle_batche: bools = False,
+        shuffle_data: bool = True,
+        order_by_length: bool = False,
     ):
         self.encode()
         if shuffle_data:
@@ -398,7 +402,7 @@ class DependencyDataset:
     def __len__(self):
         return len(self.treelist)
 
-    def oracle_labels(self, depgraph):
+    def oracle_labels(self, depgraph: DepGraph) -> List[str]:
         """
         Returns a list where each element list[i] is the label of
         the position of the governor of the word at position i.
@@ -410,7 +414,7 @@ class DependencyDataset:
         rev_labels = dict([(dep, label) for (gov, label, dep) in edges])
         return [rev_labels.get(idx, DependencyDataset.PAD_TOKEN) for idx in range(N)]
 
-    def oracle_governors(self, depgraph):
+    def oracle_governors(self, depgraph: DepGraph) -> List[int]:
         """
         Returns a list where each element list[i] is the index of
         the position of the governor of the word at position i.

--- a/npdependency/deptree.py
+++ b/npdependency/deptree.py
@@ -2,6 +2,7 @@ from random import shuffle
 from typing import Iterable, List, Tuple, overload
 
 import torch
+from torch.nn.utils.rnn import pad_sequence
 
 
 class DepGraph:
@@ -393,14 +394,12 @@ class DependencyDataset:
                 torch.tensor(padded_batchB, dtype=torch.long),
             )
         else:
-            sent_lengths = [len(sent) for sent in batch]
-            max_len = max(sent_lengths)
-            res = torch.full(
-                (len(batch), max_len), DependencyDataset.PAD_IDX, dtype=torch.long
+            tensorized_seqs = [torch.tensor(sent, dtype=torch.long) for sent in batch]
+            return pad_sequence(
+                tensorized_seqs,
+                padding_value=DependencyDataset.PAD_IDX,
+                batch_first=True,
             )
-            for i, (k, seq) in enumerate(zip(sent_lengths, batch)):
-                res[i, :k] = seq
-        return res
 
     def init_labels(self, treelist: Iterable[DepGraph]):
         self.itolab = gen_labels(treelist)

--- a/npdependency/deptree.py
+++ b/npdependency/deptree.py
@@ -380,19 +380,7 @@ class DependencyDataset:
     def pad(self, batch):
         # Ad hoc stuff for BERT Lexers
         if type(batch[0]) == tuple and len(batch[0]) == 2:
-            sent_lengths = [len(seqA) for (seqA, seqB) in batch]
-            max_len = max(sent_lengths)
-            padded_batchA, padded_batchB = [], []
-            for k, seq in zip(sent_lengths, batch):
-                seqA, seqB = seq
-                paddedA = seqA + (max_len - k) * [DependencyDataset.PAD_IDX]
-                paddedB = seqB + (max_len - k) * [self.lexer.BERT_PAD_IDX]
-                padded_batchA.append(paddedA)
-                padded_batchB.append(paddedB)
-            return (
-                torch.tensor(padded_batchA, dtype=torch.long),
-                torch.tensor(padded_batchB, dtype=torch.long),
-            )
+            return self.lexer.pad_batch(batch, padding_value=self.PAD_IDX)
         else:
             tensorized_seqs = [torch.tensor(sent, dtype=torch.long) for sent in batch]
             return pad_sequence(

--- a/npdependency/deptree.py
+++ b/npdependency/deptree.py
@@ -342,9 +342,9 @@ class DependencyDataset:
         self.encode()
         if shuffle_data:
             self.shuffle_data()
-        if (
-            order_by_length
-        ):  # shuffling and ordering is relevant : it change the way ties are resolved and thus batch construction
+        # shuffling and ordering is relevant : it change the way ties are resolved and thus batch
+        # construction
+        if order_by_length:
             self.order_data()
 
         N = len(self.encoded_words)
@@ -352,7 +352,7 @@ class DependencyDataset:
         if shuffle_batches:
             shuffle(batch_order)
         for i in batch_order:
-            deps = self.pad(self.encoded_words[i : i + batch_size])
+            encoded_words = self.pad(self.encoded_words[i : i + batch_size])
             tags = self.pad(self.tags[i : i + batch_size])
             heads = self.pad(self.heads[i : i + batch_size])
             labels = self.pad(self.labels[i : i + batch_size])
@@ -361,7 +361,7 @@ class DependencyDataset:
             cats = self.cats[i : i + batch_size]
             chars = self.char_dataset.batch_chars(self.words[i : i + batch_size])
             subwords = self.ft_dataset.batch_sentences(self.words[i : i + batch_size])
-            yield (words, mwe, chars, subwords, cats, deps, tags, heads, labels)
+            yield (words, mwe, chars, subwords, cats, encoded_words, tags, heads, labels)
 
     @overload
     def pad(self, batch: List[List[int]]) -> torch.Tensor:

--- a/npdependency/deptree.py
+++ b/npdependency/deptree.py
@@ -363,7 +363,7 @@ class DependencyDataset:
             subwords = tuple(
                 self.ft_dataset.batch_sentences([self.words[j] for j in batch_indices])
             )
-            sent_lengths = torch.tensor([len(self.encoded_words[j]) for j in batch_indices])
+            sent_lengths = torch.tensor([len(self.words[j]) for j in batch_indices])
             yield DependencyBatch(
                 words=words,
                 mwe=mwe,

--- a/npdependency/deptree.py
+++ b/npdependency/deptree.py
@@ -345,7 +345,7 @@ class DependencyDataset:
     def make_batches(
         self,
         batch_size: int,
-        shuffle_batche: bools = False,
+        shuffle_batches: bool = False,
         shuffle_data: bool = True,
         order_by_length: bool = False,
     ):

--- a/npdependency/deptree.py
+++ b/npdependency/deptree.py
@@ -308,15 +308,6 @@ class DependencyDataset:
         print(" ".join(self.itotag), file=out)
         out.close()
 
-    # !COMBAK: Some code is missing here (itos is undefined) and this function seems unused
-    # @staticmethod
-    # def load_vocab(filename):
-    #     reloaded = open(filename)
-    #     itolab = reloaded.readline().split()
-    #     itotag = reloaded.readline().split()
-    #     reloaded.close()
-    #     return itos, itolab, itotag
-
     def shuffle_data(self):
         N = len(self.encoded_words)
         order = list(range(N))

--- a/npdependency/deptree.py
+++ b/npdependency/deptree.py
@@ -277,7 +277,7 @@ class DependencyDataset:
         self.words, self.mwe_ranges, self.cats = [], [], []
 
         for tree in self.treelist:
-            depword_idxes = self.lexer.tokenize(tree.words)
+            encoded_words = self.lexer.tokenize(tree.words)
             if tree.pos_tags:
                 deptag_idxes = [
                     self.tagtoi.get(tag, self.tagtoi[DependencyDataset.UNK_WORD])
@@ -290,7 +290,7 @@ class DependencyDataset:
             self.words.append(tree.words)
             self.cats.append(tree.pos_tags)
             self.tags.append(deptag_idxes)
-            self.encoded_words.append(depword_idxes)
+            self.encoded_words.append(encoded_words)
             self.heads.append(self.oracle_governors(tree))
             # the get defaulting to 0 is a hack for labels not found in training set
             self.labels.append(

--- a/npdependency/deptree.py
+++ b/npdependency/deptree.py
@@ -358,9 +358,7 @@ class DependencyDataset:
         if shuffle_batches:
             shuffle(batch_order)
         for i in batch_order:
-            encoded_words = self.lexer.pad_batch(
-                self.encoded_words[i : i + batch_size], padding_value=self.PAD_IDX
-            )
+            encoded_words = self.lexer.pad_batch(self.encoded_words[i : i + batch_size])
             tags = self.pad(self.tags[i : i + batch_size])
             heads = self.pad(self.heads[i : i + batch_size])
             labels = self.pad(self.labels[i : i + batch_size])

--- a/npdependency/deptree.py
+++ b/npdependency/deptree.py
@@ -1,5 +1,6 @@
+import pathlib
 from random import shuffle
-from typing import Iterable, List
+from typing import Iterable, List, Union
 
 import torch
 from torch.nn.utils.rnn import pad_sequence
@@ -235,17 +236,16 @@ class DependencyDataset:
     UNK_WORD = "<unk>"
 
     @staticmethod
-    def read_conll(filename):
-        istream = open(filename)
-        treelist = []
-        tree = DepGraph.read_tree(istream)
-        while tree:
-            if len(tree.words) <= 150:
-                treelist.append(tree)
-            else:
-                print("dropped tree with length", len(tree.words))
+    def read_conll(filename: Union[str, pathlib.Path]) -> List[DepGraph]:
+        with open(filename) as istream:
+            treelist = []
             tree = DepGraph.read_tree(istream)
-        istream.close()
+            while tree:
+                if len(tree.words) <= 150:
+                    treelist.append(tree)
+                else:
+                    print(f"Dropped tree with length {len(tree.words)} > 150", )
+                tree = DepGraph.read_tree(istream)
         return treelist
 
     def __init__(

--- a/npdependency/deptree.py
+++ b/npdependency/deptree.py
@@ -402,7 +402,8 @@ class DependencyDataset:
     def __len__(self):
         return len(self.treelist)
 
-    def oracle_labels(self, depgraph: DepGraph) -> List[str]:
+    @staticmethod
+    def oracle_labels(depgraph: DepGraph) -> List[str]:
         """
         Returns a list where each element list[i] is the label of
         the position of the governor of the word at position i.
@@ -414,7 +415,8 @@ class DependencyDataset:
         rev_labels = dict([(dep, label) for (gov, label, dep) in edges])
         return [rev_labels.get(idx, DependencyDataset.PAD_TOKEN) for idx in range(N)]
 
-    def oracle_governors(self, depgraph: DepGraph) -> List[int]:
+    @staticmethod
+    def oracle_governors(depgraph: DepGraph) -> List[int]:
         """
         Returns a list where each element list[i] is the index of
         the position of the governor of the word at position i.

--- a/npdependency/deptree.py
+++ b/npdependency/deptree.py
@@ -1,6 +1,5 @@
 from typing import Iterable, List
 import torch
-from torch.autograd import Variable
 from random import shuffle
 
 
@@ -362,6 +361,7 @@ class DependencyDataset:
             subwords = self.ft_dataset.batch_sentences(self.words[i : i + batch_size])
             yield (words, mwe, chars, subwords, cats, deps, tags, heads, labels)
 
+    # TODO: make this use torch padding utility instead
     def pad(self, batch):
         if (
             type(batch[0]) == tuple and len(batch[0]) == 2
@@ -376,8 +376,8 @@ class DependencyDataset:
                 padded_batchA.append(paddedA)
                 padded_batchB.append(paddedB)
             return (
-                Variable(torch.LongTensor(padded_batchA)),
-                Variable(torch.LongTensor(padded_batchB)),
+                torch.tensor(padded_batchA, dtype=torch.long),
+                torch.tensor(padded_batchB, dtype=torch.long),
             )
         else:
             sent_lengths = list(map(len, batch))
@@ -386,7 +386,7 @@ class DependencyDataset:
             for k, seq in zip(sent_lengths, batch):
                 padded = seq + (max_len - k) * [DependencyDataset.PAD_IDX]
                 padded_batch.append(padded)
-        return Variable(torch.LongTensor(padded_batch))
+        return torch.tensor(padded_batch, dtype=torch.long)
 
     def init_labels(self, treelist: Iterable[DepGraph]):
         self.itolab = gen_labels(treelist)

--- a/npdependency/deptree.py
+++ b/npdependency/deptree.py
@@ -236,6 +236,7 @@ class DependencyBatch(NamedTuple):
     tags: torch.Tensor
     heads: torch.Tensor
     labels: torch.Tensor
+    sent_lengths: torch.Tensor
 
 
 class DependencyDataset:
@@ -362,6 +363,7 @@ class DependencyDataset:
             subwords = tuple(
                 self.ft_dataset.batch_sentences([self.words[j] for j in batch_indices])
             )
+            sent_lengths = torch.tensor([len(self.encoded_words[j]) for j in batch_indices])
             yield DependencyBatch(
                 words=words,
                 mwe=mwe,
@@ -372,6 +374,7 @@ class DependencyDataset:
                 tags=tags,
                 heads=heads,
                 labels=labels,
+                sent_lengths=sent_lengths
             )
 
     def pad(self, batch: List[List[int]]) -> torch.Tensor:

--- a/npdependency/deptree.py
+++ b/npdependency/deptree.py
@@ -267,7 +267,7 @@ class DependencyDataset:
             self.init_tags(self.treelist)
 
     def encode(self):
-        self.deps, self.heads, self.labels, self.tags = [], [], [], []
+        self.encoded_words, self.heads, self.labels, self.tags = [], [], [], []
         self.words, self.mwe_ranges, self.cats = [], [], []
 
         for tree in self.treelist:
@@ -284,7 +284,7 @@ class DependencyDataset:
             self.words.append(tree.words)
             self.cats.append(tree.pos_tags)
             self.tags.append(deptag_idxes)
-            self.deps.append(depword_idxes)
+            self.encoded_words.append(depword_idxes)
             self.heads.append(self.oracle_governors(tree))
             # the get defaulting to 0 is a hack for labels not found in training set
             self.labels.append(
@@ -308,10 +308,10 @@ class DependencyDataset:
     #     return itos, itolab, itotag
 
     def shuffle_data(self):
-        N = len(self.deps)
+        N = len(self.encoded_words)
         order = list(range(N))
         shuffle(order)
-        self.deps = [self.deps[i] for i in order]
+        self.encoded_words = [self.encoded_words[i] for i in order]
         self.tags = [self.tags[i] for i in order]
         self.heads = [self.heads[i] for i in order]
         self.labels = [self.labels[i] for i in order]
@@ -320,11 +320,11 @@ class DependencyDataset:
         self.mwe_ranges = [self.mwe_ranges[i] for i in order]
 
     def order_data(self):
-        N = len(self.deps)
+        N = len(self.encoded_words)
         order = list(range(N))
-        lengths = map(len, self.deps)
+        lengths = map(len, self.encoded_words)
         order = [idx for idx, L in sorted(zip(order, lengths), key=lambda x: x[1])]
-        self.deps = [self.deps[idx] for idx in order]
+        self.encoded_words = [self.encoded_words[idx] for idx in order]
         self.tags = [self.tags[idx] for idx in order]
         self.heads = [self.heads[idx] for idx in order]
         self.labels = [self.labels[idx] for idx in order]
@@ -347,12 +347,12 @@ class DependencyDataset:
         ):  # shuffling and ordering is relevant : it change the way ties are resolved and thus batch construction
             self.order_data()
 
-        N = len(self.deps)
+        N = len(self.encoded_words)
         batch_order = list(range(0, N, batch_size))
         if shuffle_batches:
             shuffle(batch_order)
         for i in batch_order:
-            deps = self.pad(self.deps[i : i + batch_size])
+            deps = self.pad(self.encoded_words[i : i + batch_size])
             tags = self.pad(self.tags[i : i + batch_size])
             heads = self.pad(self.heads[i : i + batch_size])
             labels = self.pad(self.labels[i : i + batch_size])

--- a/npdependency/graph_parser.py
+++ b/npdependency/graph_parser.py
@@ -515,13 +515,10 @@ class BiAffineParser(nn.Module):
                 unk_word=DependencyDataset.UNK_WORD,
             )
         else:
-            bert_model_name = hp["lexer"].split("/")[-1]
-            cased = hp.get("cased", "uncased" not in bert_model_name)
             lexer = BertBaseLexer(
                 itos=ordered_vocab,
                 embedding_size=hp["word_embedding_size"],
                 word_dropout=hp["word_dropout"],
-                cased=cased,
                 bert_modelfile=hp["lexer"],
                 bert_layers=hp.get("bert_layers", [4, 5, 6, 7]),
                 bert_weighted=hp.get("bert_weighted", False),

--- a/npdependency/graph_parser.py
+++ b/npdependency/graph_parser.py
@@ -162,6 +162,7 @@ class BiAffineParser(nn.Module):
         self.load_state_dict(state_dict)
 
     def forward(self, xwords, xchars, xft):
+        # FIXME: can't these be batched?
         """Computes char embeddings"""
         char_embed = torch.stack([self.char_rnn(column) for column in xchars], dim=1)
         """ Computes fasttext embeddings """
@@ -667,6 +668,7 @@ def main():
     else:
         overrides = dict()
 
+    # TODO: warn about unused parameters in config
     config_file = os.path.abspath(args.config_file)
     if args.train_file and args.out_dir:
         model_dir = os.path.join(args.out_dir, "model")

--- a/npdependency/graph_parser.py
+++ b/npdependency/graph_parser.py
@@ -563,6 +563,9 @@ class BiAffineParser(nn.Module):
         weights_file = config_dir / "model.pt"
         if weights_file.exists():
             parser.load_params(str(weights_file))
+
+        if hp.get("freeze_fasttext", False):
+            freeze_module(ft_lexer)
         if hp.get("freeze_bert", False):
             try:
                 freeze_module(lexer.bert)

--- a/npdependency/graph_parser.py
+++ b/npdependency/graph_parser.py
@@ -769,10 +769,17 @@ def main():
             else:
                 raise ValueError(f"{args.fasttext} not found")
 
-            ordered_vocab = make_vocab(traintrees, 0)
+            ordered_vocab = make_vocab(
+                [word for tree in traintrees for word in tree.words],
+                0,
+                unk_word=DependencyDataset.UNK_WORD,
+                pad_token=DependencyDataset.PAD_TOKEN,
+            )
             savelist(ordered_vocab, os.path.join(model_dir, "vocab.lst"))
 
-            ordered_charset = CharDataSet.make_vocab(ordered_vocab)
+            ordered_charset = CharDataSet.make_vocab(
+                ordered_vocab, pad_token=DependencyDataset.PAD_TOKEN
+            )
             savelist(ordered_charset.i2c, os.path.join(model_dir, "charcodes.lst"))
 
             itolab = gen_labels(traintrees)

--- a/npdependency/graph_parser.py
+++ b/npdependency/graph_parser.py
@@ -434,14 +434,31 @@ class BiAffineParser(nn.Module):
 
         with torch.no_grad():
             for batch in test_batches:
-                words, mwe, chars, subwords, cats, encoded_words, tags, heads, labels = batch
+                (
+                    words,
+                    mwe,
+                    chars,
+                    subwords,
+                    cats,
+                    encoded_words,
+                    tags,
+                    heads,
+                    labels,
+                ) = batch
                 if type(encoded_words) == tuple:
                     base_words, bert_subwords = encoded_words
-                    encoded_words = (base_words.to(self.device), bert_subwords.to(self.device))
-                    SLENGTHS = (base_words != DependencyDataset.PAD_IDX).long().sum(-1)
+                    encoded_words = (
+                        base_words.to(self.device),
+                        bert_subwords.to(self.device),
+                    )
+                    sent_lengths = (
+                        (base_words != DependencyDataset.PAD_IDX).long().sum(-1)
+                    )
                 else:
                     encoded_words = encoded_words.to(self.device)
-                    SLENGTHS = (encoded_words != DependencyDataset.PAD_IDX).long().sum(-1)
+                    sent_lengths = (
+                        (encoded_words != DependencyDataset.PAD_IDX).long().sum(-1)
+                    )
                 heads, labels, tags = (
                     heads.to(self.device),
                     labels.to(self.device),
@@ -470,7 +487,7 @@ class BiAffineParser(nn.Module):
                 ) in zip(
                     words,
                     mwe,
-                    SLENGTHS,
+                    sent_lengths,
                     tagger_scores_batch,
                     arc_scores_batch,
                     lab_scores_batch,

--- a/npdependency/graph_parser.py
+++ b/npdependency/graph_parser.py
@@ -295,8 +295,8 @@ class BiAffineParser(nn.Module):
         scheduler = torch.optim.lr_scheduler.ExponentialLR(optimizer, gamma=0.95)
 
         for e in range(epochs):
-            TRAIN_LOSS = 0
-            BEST_ARC_ACC = 0
+            TRAIN_LOSS = 0.0
+            BEST_ARC_ACC = 0.0
             train_batches = train_set.make_batches(
                 batch_size,
                 shuffle_batches=True,
@@ -563,6 +563,8 @@ class BiAffineParser(nn.Module):
         weights_file = config_dir / "model.pt"
         if weights_file.exists():
             parser.load_params(str(weights_file))
+        else:
+            parser.save_params(str(weights_file))
 
         if hp.get("freeze_fasttext", False):
             freeze_module(ft_lexer)

--- a/npdependency/graph_parser.py
+++ b/npdependency/graph_parser.py
@@ -214,18 +214,9 @@ class BiAffineParser(nn.Module):
                     heads,
                     labels,
                 ) = batch
-                if type(encoded_words) == tuple:
-                    base_words, bert_subwords = encoded_words
-                    encoded_words = (
-                        base_words.to(self.device),
-                        bert_subwords.to(self.device),
-                    )
-                    # bc no masking at training
-                    overall_size += base_words.size(0) * base_words.size(1)
-                else:
-                    encoded_words = encoded_words.to(self.device)
-                    # bc no masking at training
-                    overall_size += encoded_words.size(0) * encoded_words.size(1)
+                encoded_words = encoded_words.to(self.device)
+                # bc no masking at training
+                overall_size += encoded_words.size(0) * encoded_words.size(1)
                 heads, labels, tags = (
                     heads.to(self.device),
                     labels.to(self.device),
@@ -252,7 +243,7 @@ class BiAffineParser(nn.Module):
 
                 # LABEL LOSS
                 # [batch, 1, 1, sent_len]
-                headsL = heads.unsqueeze(1).unsqueeze(2)  
+                headsL = heads.unsqueeze(1).unsqueeze(2)
                 # [batch, n_labels, 1, sent_len]
                 headsL = headsL.expand(-1, lab_scores.size(1), -1, -1)
                 # [batch, n_labels, sent_len]
@@ -323,18 +314,9 @@ class BiAffineParser(nn.Module):
                     heads,
                     labels,
                 ) = batch
-                if type(encoded_words) == tuple:
-                    base_words, bert_subwords = encoded_words
-                    encoded_words = (
-                        base_words.to(self.device),
-                        bert_subwords.to(self.device),
-                    )
-                    # bc no masking at training
-                    overall_size += base_words.size(0) * base_words.size(1)
-                else:
-                    encoded_words = encoded_words.to(self.device)
-                    # bc no masking at training
-                    overall_size += encoded_words.size(0) * encoded_words.size(1)
+                encoded_words = encoded_words.to(self.device)
+                # bc no masking at training
+                overall_size += encoded_words.size(0) * encoded_words.size(1)
                 heads, labels, tags = (
                     heads.to(self.device),
                     labels.to(self.device),
@@ -433,16 +415,8 @@ class BiAffineParser(nn.Module):
                     heads,
                     labels,
                 ) = batch
-                if type(encoded_words) == tuple:
-                    base_words, bert_subwords = encoded_words
-                    encoded_words = (
-                        base_words.to(self.device),
-                        bert_subwords.to(self.device),
-                    )
-                    sent_lengths = base_words.ne(test_set.PAD_IDX).sum(-1)
-                else:
-                    encoded_words = encoded_words.to(self.device)
-                    sent_lengths = encoded_words.ne(test_set.PAD_IDX).sum(-1)
+                encoded_words = encoded_words.to(self.device)
+                sent_lengths = [len(s) for s in words]
                 heads, labels, tags = (
                     heads.to(self.device),
                     labels.to(self.device),

--- a/npdependency/graph_parser.py
+++ b/npdependency/graph_parser.py
@@ -458,7 +458,7 @@ class BiAffineParser(nn.Module):
                         if greedy
                         else chuliu_edmonds(probs[:length, :length])
                     )
-                    mst_heads = np.pad(mst_heads, (0, batch_width - length)
+                    mst_heads = np.pad(mst_heads, (0, batch_width - length))
 
                     # Predict tags
                     tag_probs = tagger_scores.numpy()

--- a/npdependency/graph_parser.py
+++ b/npdependency/graph_parser.py
@@ -752,8 +752,8 @@ def main():
                         )
                         os.remove(fasttext_model_path)
                     print(f"Generating a FastText model from {args.train_file}")
-                    FastTextTorch.train_model_from_trees(
-                        traintrees, fasttext_model_path
+                    FastTextTorch.train_model_from_sents(
+                        [tree.words[1:] for tree in traintrees], fasttext_model_path
                     )
             elif os.path.exists(args.fasttext):
                 if os.path.exists(fasttext_model_path):

--- a/npdependency/graph_parser.py
+++ b/npdependency/graph_parser.py
@@ -1,6 +1,6 @@
 import pathlib
 import sys
-from typing import Any, Dict, Union
+from typing import Any, Dict, Sequence, Union
 import yaml
 import argparse
 
@@ -80,23 +80,23 @@ class BiAffineParser(nn.Module):
 
     def __init__(
         self,
-        lexer,
-        charset,
-        char_rnn,
-        ft_lexer,
-        tagset,
-        encoder_dropout,  # lstm dropout
-        mlp_input,
-        mlp_tag_hidden,
-        mlp_arc_hidden,
-        mlp_lab_hidden,
-        mlp_dropout,
-        labels,
-        device,
+        lexer: Union[DefaultLexer, BertBaseLexer],
+        charset: CharDataSet,
+        char_rnn: CharRNN,
+        ft_lexer: FastTextTorch,
+        tagset: Sequence[str],
+        encoder_dropout: float,  # lstm dropout
+        mlp_input: int,
+        mlp_tag_hidden: int,
+        mlp_arc_hidden: int,
+        mlp_lab_hidden: int,
+        mlp_dropout: float,
+        labels: Sequence[str],
+        device: Union[str, torch.device],
     ):
 
         super(BiAffineParser, self).__init__()
-        self.device = torch.device(device) if type(device) == str else device
+        self.device = torch.device(device)
         self.lexer = lexer.to(self.device)
         self.dep_rnn = nn.LSTM(
             self.lexer.embedding_size
@@ -521,6 +521,7 @@ class BiAffineParser(nn.Module):
                 word_dropout=hp["word_dropout"],
                 bert_modelfile=hp["lexer"],
                 bert_layers=hp.get("bert_layers", [4, 5, 6, 7]),
+                bert_subwords_reduction=hp.get("bert_subwords_reduction", "first"),
                 bert_weighted=hp.get("bert_weighted", False),
                 words_padding_idx=DependencyDataset.PAD_IDX,
                 unk_word=DependencyDataset.UNK_WORD,

--- a/npdependency/graph_parser.py
+++ b/npdependency/graph_parser.py
@@ -283,7 +283,7 @@ class BiAffineParser(nn.Module):
         self, train_set, dev_set, epochs, batch_size, lr, modelpath="test_model.pt"
     ):
 
-        print("start training", flush=True)
+        print(f"Start training on {self.device}", flush=True)
         loss_fnc = nn.CrossEntropyLoss(reduction="sum")
 
         optimizer = torch.optim.Adam(

--- a/npdependency/graph_parser.py
+++ b/npdependency/graph_parser.py
@@ -223,9 +223,7 @@ class BiAffineParser(nn.Module):
                 chars = [token.to(self.device) for token in chars]
                 subwords = [token.to(self.device) for token in subwords]
                 # preds
-                tagger_scores, arc_scores, lab_scores = self.forward(
-                    deps, chars, subwords
-                )
+                tagger_scores, arc_scores, lab_scores = self(deps, chars, subwords)
 
                 # get global loss
                 # ARC LOSS
@@ -329,9 +327,7 @@ class BiAffineParser(nn.Module):
                 subwords = [token.to(self.device) for token in subwords]
 
                 # FORWARD
-                tagger_scores, arc_scores, lab_scores = self.forward(
-                    deps, chars, subwords
-                )
+                tagger_scores, arc_scores, lab_scores = self(deps, chars, subwords)
 
                 # ARC LOSS
                 arc_scores = arc_scores.transpose(-1, -2)  # [batch, sent_len, sent_len]
@@ -425,7 +421,7 @@ class BiAffineParser(nn.Module):
                 subwords = [token.to(self.device) for token in subwords]
 
                 # batch prediction
-                tagger_scores_batch, arc_scores_batch, lab_scores_batch = self.forward(
+                tagger_scores_batch, arc_scores_batch, lab_scores_batch = self(
                     deps, chars, subwords
                 )
                 tagger_scores_batch, arc_scores_batch, lab_scores_batch = (

--- a/npdependency/graph_parser.py
+++ b/npdependency/graph_parser.py
@@ -192,7 +192,8 @@ class BiAffineParser(nn.Module):
 
         loss_fnc = nn.CrossEntropyLoss(reduction="sum")
 
-        # Note: the accurracy scoring is approximative and cannot be interpreted as an UAS/LAS score !
+        # Note: the accurracy scoring is approximative and cannot be interpreted as an UAS/LAS score
+        # Note: fun project: tracke the correlation between them
 
         self.eval()
 

--- a/npdependency/graph_parser.py
+++ b/npdependency/graph_parser.py
@@ -458,7 +458,7 @@ class BiAffineParser(nn.Module):
                         if greedy
                         else chuliu_edmonds(probs[:length, :length])
                     )
-                    mst_heads = np.pad(mst_heads, (0, batch_width - length.item()))
+                    mst_heads = np.pad(mst_heads, (0, batch_width - length)
 
                     # Predict tags
                     tag_probs = tagger_scores.numpy()

--- a/npdependency/graph_parser.py
+++ b/npdependency/graph_parser.py
@@ -733,6 +733,8 @@ def main():
             else:
                 raise ValueError(f"{args.fasttext} not found")
 
+            # NOTE: these include the [ROOT] token, which will thus automatically have a dedicated
+            # word embeddings in layers based on this vocab
             ordered_vocab = make_vocab(
                 [word for tree in traintrees for word in tree.words],
                 0,
@@ -756,7 +758,7 @@ def main():
 
         parser = BiAffineParser.from_config(config_file, overrides)
 
-        ft_dataset = FastTextDataSet(parser.ft_lexer)
+        ft_dataset = FastTextDataSet(parser.ft_lexer, special_tokens=[DepGraph.ROOT_TOKEN])
         trainset = DependencyDataset(
             traintrees,
             parser.lexer,
@@ -810,7 +812,8 @@ def main():
         parser = BiAffineParser.from_config(config_file, overrides)
         parser.eval()
         testtrees = DependencyDataset.read_conll(args.pred_file)
-        ft_dataset = FastTextDataSet(parser.ft_lexer)
+        # FIXME: the special tokens should be saved somewhere instead of hardcoded
+        ft_dataset = FastTextDataSet(parser.ft_lexer, special_tokens=[DepGraph.ROOT_TOKEN])
         testset = DependencyDataset(
             testtrees,
             parser.lexer,

--- a/npdependency/graph_parser.py
+++ b/npdependency/graph_parser.py
@@ -570,7 +570,10 @@ class BiAffineParser(nn.Module):
             )
 
         # char rnn processor
-        ordered_charset = CharDataSet(loadlist(config_dir / "charcodes.lst"))
+        ordered_charset = CharDataSet(
+            loadlist(config_dir / "charcodes.lst"),
+            special_tokens=[DepGraph.ROOT_TOKEN],
+        )
         char_rnn = CharRNN(
             len(ordered_charset), hp["char_embedding_size"], hp["charlstm_output_size"]
         )
@@ -777,8 +780,10 @@ def main():
             )
             savelist(ordered_vocab, os.path.join(model_dir, "vocab.lst"))
 
-            ordered_charset = CharDataSet.make_vocab(
-                ordered_vocab, pad_token=DependencyDataset.PAD_TOKEN
+            # FIXME: A better save that can restore special tokens is probably a good idea
+            ordered_charset = CharDataSet.from_words(
+                ordered_vocab,
+                special_tokens=[DepGraph.ROOT_TOKEN],
             )
             savelist(ordered_charset.i2c, os.path.join(model_dir, "charcodes.lst"))
 

--- a/npdependency/graph_parser.py
+++ b/npdependency/graph_parser.py
@@ -210,7 +210,7 @@ class BiAffineParser(nn.Module):
         self.eval()
 
         dev_batches = dev_set.make_batches(
-            batch_size, shuffle_batches=True, shuffle_data=True, order_by_length=True
+            batch_size, shuffle_batches=False, shuffle_data=False, order_by_length=True
         )
         tag_acc, arc_acc, lab_acc, gloss, accZ = 0, 0, 0, 0, 0
         overall_size = 0
@@ -320,7 +320,7 @@ class BiAffineParser(nn.Module):
                 batch_size,
                 shuffle_batches=True,
                 shuffle_data=True,
-                order_by_length=True,
+                order_by_length=False,
             )
             overall_size = 0
             self.train()

--- a/npdependency/lexers.py
+++ b/npdependency/lexers.py
@@ -318,6 +318,8 @@ class DefaultLexer(nn.Module):
            a list of integers
         """
         word_idxes = [self.stoi.get(token, self.unk_word_idx) for token in tok_sequence]
+        # FIXME: word dropout is probably better in forward, since that way it would change at every
+        # epoch
         if self._dpout > 0:
             word_idxes = [
                 word_sampler(widx, self.unk_word_idx, self._dpout)
@@ -546,14 +548,11 @@ class BertBaseLexer(nn.Module):
         Args:
            tok_sequence: a sequence of strings
         """
-        # FIXME: I think the padding here is mixed up with whatever happens to be self.stoi[0]
         word_idxes = [self.stoi.get(token, self.unk_word_idx) for token in tok_sequence]
-        # TODO: the root token should have a special embedding instead of unk
-        word_idxes[0] = self.unk_word_idx
 
         # We deal with the root token separately since the BERT model has no reason to know of it
         unrooted_tok_sequence = tok_sequence[1:]
-        # NOTE: for now the 🤗 tokenizer interface is not unified between dast and non-fast
+        # NOTE: for now the 🤗 tokenizer interface is not unified between fast and non-fast
         # tokenizers AND not all tokenizers support the fast mode, so we have to do this little
         # awkward dance. Eventually we should be able to remove the non-fast branch here.
         if self.bert_tokenizer.is_fast:

--- a/npdependency/lexers.py
+++ b/npdependency/lexers.py
@@ -10,8 +10,6 @@ from collections import Counter
 from random import random  # nosec:B311
 from tempfile import gettempdir
 
-from npdependency.deptree import DependencyDataset, DepGraph
-
 if TYPE_CHECKING:
     from npdependency.deptree import DepGraph  # noqa: F811
 
@@ -400,12 +398,6 @@ class BertBaseLexer(nn.Module):
             padding_idx=words_padding_idx,
         )
 
-        # ! FIXME: this is still somewhat brittle, since the BERT models have not been trained with
-        # ! the root token at sentence beginning. Maybe we could use the BOS token for that purpose
-        # ! instead?
-        self.bert_tokenizer.add_tokens([DepGraph.ROOT_TOKEN], special_tokens=True)
-        self.bert.resize_token_embeddings(len(self.bert_tokenizer))
-
         self.word_dropout = word_dropout
         self._dpout = 0.0
         self.cased = cased
@@ -503,7 +495,7 @@ class BertBaseLexer(nn.Module):
 
         # TODO: in the two line below, change unk to a spe
         word_idxes[0] = self.unk_word_idx
-        bert_idxes[0] = self.bert_tokenizer.convert_tokens_to_ids(DepGraph.ROOT_TOKEN)
+        bert_idxes[0] = 0
         return (word_idxes, bert_idxes)
 
 

--- a/npdependency/lexers.py
+++ b/npdependency/lexers.py
@@ -1,5 +1,4 @@
 from typing import (
-    Generator,
     Iterable,
     List,
     Literal,
@@ -93,9 +92,7 @@ class CharDataSet:
         ]
         return pad_sequence(charcodes, padding_value=self.PAD_IDX, batch_first=True)
 
-    def batch_chars(
-        self, sent_batch: List[List[str]]
-    ) -> Generator[torch.Tensor, None, None]:
+    def batch_chars(self, sent_batch: List[List[str]]) -> Iterable[torch.Tensor]:
         """
         Batches a list of sentences such that each sentence is padded with the same word length.
         :yields: the character encodings for each word position in this batch of sentences
@@ -182,9 +179,7 @@ class FastTextDataSet:
         subcodes = [self.word2subcodes(token) for token in token_sequence]
         return pad_sequence(subcodes, padding_value=self.PAD_IDX, batch_first=True)
 
-    def batch_sentences(
-        self, sent_batch: List[List[str]]
-    ) -> Generator[torch.Tensor, None, None]:
+    def batch_sentences(self, sent_batch: List[List[str]]) -> Iterable[torch.Tensor]:
         """
         Batches a list of sentences such that each sentence is padded with the same word length.
         :yields: the subword encodings for each word position in this batch of sentences

--- a/npdependency/lexers.py
+++ b/npdependency/lexers.py
@@ -1,4 +1,4 @@
-from typing import Iterable, List, Optional, Sequence, Tuple, Union
+from typing import Generator, Iterable, List, Optional, Sequence, Tuple, Union
 import torch
 import fasttext
 import os.path
@@ -83,7 +83,7 @@ class CharDataSet:
         ]
         return pad_sequence(charcodes, padding_value=self.PAD_IDX, batch_first=True)
 
-    def batch_chars(self, sent_batch: List[str]) -> List[torch.Tensor]:
+    def batch_chars(self, sent_batch: List[str]) -> Generator[torch.Tensor, None, None]:
         """
         Batches a list of sentences such that each sentence is padded with the same word length.
         :yields: the character encodings for each word position in this batch of sentences
@@ -169,7 +169,9 @@ class FastTextDataSet:
         subcodes = [self.word2subcodes(token) for token in token_sequence]
         return pad_sequence(subcodes, padding_value=self.PAD_IDX, batch_first=True)
 
-    def batch_sentences(self, sent_batch: List[str]) -> List[torch.Tensor]:
+    def batch_sentences(
+        self, sent_batch: List[str]
+    ) -> Generator[torch.Tensor, None, None]:
         """
         Batches a list of sentences such that each sentence is padded with the same word length.
         :yields: the subword encodings for each word position in this batch of sentences

--- a/npdependency/lexers.py
+++ b/npdependency/lexers.py
@@ -11,7 +11,6 @@ import torch
 import torch.jit
 import fasttext
 import os.path
-import numpy as np
 from torch import nn
 from torch.nn.utils.rnn import pad_sequence
 from transformers import AutoModel, AutoTokenizer
@@ -157,7 +156,6 @@ class CharRNN(nn.Module):
         return result
 
 
-# TODO: root/special token handling
 class FastTextDataSet:
     """
     Namespace for simulating a fasttext encoded dataset.
@@ -368,6 +366,8 @@ def freeze_module(module, freezing: bool = True):
       eval mode that you might want to use), you have to do that yourself.
     - Manually setting the submodules of a frozen module to train is not disabled, but if you want
       to do that, writing a custom freezing function is probably a better idea.
+    - Freezing does not save the parameters `requires_grad`, so if some parameters do not require
+      grad even at training, this will mess that up. Again, in that case, write a custom function.
     """
 
     # This will replace the module's train function when freezing
@@ -377,11 +377,9 @@ def freeze_module(module, freezing: bool = True):
     if freezing:
         module.eval()
         module.train = no_train
-        for p in module.parameters():
-            p.requires_grad = False
+        module.requires_grad_(False)
     else:
-        for p in module.parameters():
-            p.requires_grad = True
+        module.requires_grad_(True)
         module.train = type(module).train
 
 

--- a/npdependency/lexers.py
+++ b/npdependency/lexers.py
@@ -1,4 +1,4 @@
-from typing import List, Sequence, Tuple
+from typing import List, Sequence, Tuple, Union
 import torch
 import fasttext
 import os.path
@@ -301,9 +301,7 @@ class DefaultLexer(nn.Module):
         self, batch: Sequence[Sequence[int]], padding_value: int = 0
     ) -> torch.Tensor:
         """Pad a batch of sentences."""
-        tensorized_sents = [
-            torch.tensor(sent, dtype=torch.long) for sent in batch
-        ]
+        tensorized_sents = [torch.tensor(sent, dtype=torch.long) for sent in batch]
         return pad_sequence(
             tensorized_sents,
             padding_value=padding_value,
@@ -428,9 +426,11 @@ class BertBaseLexer(nn.Module):
             bertE = selected_bert_layers.mean(dim=0)
         wordE = self.embedding(word_idxes)
         return torch.cat((wordE, bertE), dim=2)
-    
+
     def pad_batch(
-        self, batch: Sequence[Tuple[Sequence[int], Sequence[int]]], padding_value: int = 0
+        self,
+        batch: Sequence[Tuple[Sequence[int], Sequence[int]]],
+        padding_value: int = 0,
     ) -> Tuple[torch.Tensor, torch.Tensor]:
         """Pad a batch of sentences."""
         words_batch, bert_batch = [], []
@@ -479,3 +479,6 @@ class BertBaseLexer(nn.Module):
         word_idxes[0] = self.stoi[DependencyDataset.UNK_WORD]
         bert_idxes[0] = self.bert_tokenizer.convert_tokens_to_ids(DepGraph.ROOT_TOKEN)
         return (word_idxes, bert_idxes)
+
+
+Lexer = Union[DefaultLexer, BertBaseLexer]

--- a/npdependency/lexers.py
+++ b/npdependency/lexers.py
@@ -9,6 +9,7 @@ from typing import (
 )
 import torch
 import torch.jit
+import transformers
 import fasttext
 import os.path
 from torch import nn
@@ -463,6 +464,11 @@ class BertBaseLexer(nn.Module):
         self.bert_tokenizer = AutoTokenizer.from_pretrained(
             bert_modelfile, use_fast=True
         )
+        # Shim for the weird idiosyncrasies of the RoBERTa tokenizer
+        if isinstance(self.bert_tokenizer, transformers.GPT2TokenizerFast):
+            self.bert_tokenizer = AutoTokenizer.from_pretrained(
+                bert_modelfile, use_fast=True, add_prefix_space=True
+            )
 
         self.BERT_PAD_IDX = self.bert_tokenizer.pad_token_id
         self.BERT_UNK_IDX = self.bert_tokenizer.unk_token_id

--- a/npdependency/lexers.py
+++ b/npdependency/lexers.py
@@ -76,17 +76,17 @@ class CharDataSet:
     def word2charcodes(self, token: str) -> List[int]:
         """
         Turns a string into a list of char codes.
-        If the string is <pad> returns an empty list of char codes
         """
         if token in self.special_tokens:
             return [self.SPECIAL_TOKENS_IDX]
-        return [self.c2idx[c] for c in token if c in self.c2idx]
+        res = [self.c2idx[c] for c in token if c in self.c2idx]
+        if not res:
+            return [self.PAD_IDX]
+        return res
 
     def batchedtokens2codes(self, toklist: List[str]) -> torch.Tensor:
         """
         Codes a list of tokens as a batch of lists of charcodes and pads them if needed
-        :param toklist:
-        :return:
         """
         charcodes = [
             torch.tensor(self.word2charcodes(token), dtype=torch.long)

--- a/npdependency/lexers.py
+++ b/npdependency/lexers.py
@@ -219,14 +219,13 @@ class FastTextTorch(nn.Module):
             raise ValueError(f"{target_file} already exists!")
         else:
             source_file = os.path.join(gettempdir(), "source.ft")
-            source_stream = open(source_file, "w")
-            print(
-                "\n".join(
-                    [" ".join(tree.words[1:]) for tree in reversed(source_trees)]
-                ),
-                file=source_stream,
-            )
-            source_stream.close()
+            with open(source_file, "w") as source_stream:
+                print(
+                    "\n".join(
+                        [" ".join(tree.words[1:]) for tree in reversed(source_trees)]
+                    ),
+                    file=source_stream,
+                )
 
             print("Training fasttext model...")
             model = fasttext.train_unsupervised(

--- a/npdependency/lexers.py
+++ b/npdependency/lexers.py
@@ -93,7 +93,9 @@ class CharDataSet:
         ]
         return pad_sequence(charcodes, padding_value=self.PAD_IDX, batch_first=True)
 
-    def batch_chars(self, sent_batch: List[str]) -> Generator[torch.Tensor, None, None]:
+    def batch_chars(
+        self, sent_batch: List[List[str]]
+    ) -> Generator[torch.Tensor, None, None]:
         """
         Batches a list of sentences such that each sentence is padded with the same word length.
         :yields: the character encodings for each word position in this batch of sentences
@@ -181,7 +183,7 @@ class FastTextDataSet:
         return pad_sequence(subcodes, padding_value=self.PAD_IDX, batch_first=True)
 
     def batch_sentences(
-        self, sent_batch: List[str]
+        self, sent_batch: List[List[str]]
     ) -> Generator[torch.Tensor, None, None]:
         """
         Batches a list of sentences such that each sentence is padded with the same word length.

--- a/npdependency/lexers.py
+++ b/npdependency/lexers.py
@@ -232,6 +232,7 @@ class FastTextTorch(nn.Module):
         weights = torch.cat((weights, torch.zeros((2, self.embedding_size))), dim=0).to(
             torch.float
         )
+        weights.requires_grad = True
         self.embeddings = nn.Embedding.from_pretrained(
             weights, padding_idx=self.vocab_size + 1
         )

--- a/npdependency/lexers.py
+++ b/npdependency/lexers.py
@@ -1,4 +1,4 @@
-from typing import Iterable, List, Optional, Sequence, TYPE_CHECKING, Tuple, Union
+from typing import Iterable, List, Optional, Sequence, Tuple, Union
 import torch
 import fasttext
 import os.path
@@ -9,9 +9,6 @@ from transformers import AutoModel, AutoTokenizer
 from collections import Counter
 from random import random  # nosec:B311
 from tempfile import gettempdir
-
-if TYPE_CHECKING:
-    from npdependency.deptree import DepGraph  # noqa: F811
 
 # Python 3.7 shim
 try:
@@ -183,10 +180,7 @@ class FastTextDataSet:
 
         # The empty string here serves as padding, which, contrarily to CharsDataSet is a bit ugly,
         # since we intercept it instead of passing it to FastText
-        batched_sents = [
-            ["" for _ in range(max_sent_len)]
-            for _ in sent_batch
-        ]
+        batched_sents = [["" for _ in range(max_sent_len)] for _ in sent_batch]
         for batch_sent, l, sent in zip(batched_sents, sent_lengths, sent_batch):
             batch_sent[:l] = sent
 
@@ -231,8 +225,8 @@ class FastTextTorch(nn.Module):
         return cls(fasttext.load_model(modelfile))
 
     @classmethod
-    def train_model_from_trees(
-        cls, source_trees: Sequence["DepGraph"], target_file: str
+    def train_model_from_sents(
+        cls, source_sents: Iterable[List[str]], target_file: str
     ) -> "FastTextTorch":
         if os.path.exists(target_file):
             raise ValueError(f"{target_file} already exists!")
@@ -240,9 +234,7 @@ class FastTextTorch(nn.Module):
             source_file = os.path.join(gettempdir(), "source.ft")
             with open(source_file, "w") as source_stream:
                 print(
-                    "\n".join(
-                        [" ".join(tree.words[1:]) for tree in reversed(source_trees)]
-                    ),
+                    "\n".join([" ".join(sent) for sent in source_sents]),
                     file=source_stream,
                 )
 

--- a/npdependency/lexers.py
+++ b/npdependency/lexers.py
@@ -150,6 +150,7 @@ class CharRNN(nn.Module):
         :return: a word embedding tensor
         """
         embeddings = self.char_embedding(xinput)
+        # ! FIXME: this does not take the padding into account
         outputs, (_, cembedding) = self.char_bilstm(embeddings)
         # TODO: why use the cell state and not the output state here?
         result = cembedding.view(-1, self.embedding_size)

--- a/npdependency/lexers.py
+++ b/npdependency/lexers.py
@@ -398,7 +398,6 @@ class BertBaseLexer(nn.Module):
         bert_weighted: bool,
         words_padding_idx: int,
         unk_word: str,
-        cased: bool = False,
     ):
 
         super(BertBaseLexer, self).__init__()
@@ -423,7 +422,6 @@ class BertBaseLexer(nn.Module):
 
         self.word_dropout = word_dropout
         self._dpout = 0.0
-        self.cased = cased
 
         self.bert_layers = bert_layers
         self.bert_weighted = bert_weighted
@@ -497,16 +495,9 @@ class BertBaseLexer(nn.Module):
         """
         # FIXME: I think the padding here is mixed up with whatever happens to be self.stoi[0]
         word_idxes = [self.stoi.get(token, self.unk_word_idx) for token in tok_sequence]
-        # ? COMBAK: lowercasing should be done by the loaded tokenizer or am I missing something
-        # ? here? (2020-11-08)
-        if self.cased:
-            bert_tokens = [
-                self.bert_tokenizer.tokenize(token) for token in tok_sequence
-            ]
-        else:
-            bert_tokens = [
-                self.bert_tokenizer.tokenize(token.lower()) for token in tok_sequence
-            ]
+        bert_tokens = [
+            self.bert_tokenizer.tokenize(token) for token in tok_sequence
+        ]
         bert_idxes = [
             self.bert_tokenizer.convert_tokens_to_ids(token)[0] for token in bert_tokens
         ]

--- a/npdependency/lexers.py
+++ b/npdependency/lexers.py
@@ -124,7 +124,7 @@ class CharRNN(nn.Module):
         )
         self.char_bilstm = nn.LSTM(
             char_embedding_size,
-            int(self.embedding_size / 2),
+            self.embedding_size // 2,
             1,
             batch_first=True,
             bidirectional=True,
@@ -138,6 +138,7 @@ class CharRNN(nn.Module):
         """
         embeddings = self.char_embedding(xinput)
         outputs, (_, cembedding) = self.char_bilstm(embeddings)
+        # TODO: why use the cell state and not the output state here?
         result = cembedding.view(-1, self.embedding_size)
         return result
 
@@ -466,6 +467,7 @@ class BertBaseLexer(nn.Module):
         Returns:
            a list of integers
         """
+        # FIXME: I think the padding here is mixed up with whatever happens to be self.stoi[0]
         word_idxes = [self.stoi.get(token, self.unk_word_idx) for token in tok_sequence]
         # ? COMBAK: lowercasing should be done by the loaded tokenizer or am I missing something
         # ? here? (2020-11-08)

--- a/setup.cfg
+++ b/setup.cfg
@@ -20,7 +20,7 @@ install_requires =
     click_pathlib
     fasttext
     torch >= 1.6, < 2.0.0
-    transformers >= 3.2.0, < 4.0.0
+    transformers >= 3.5.1, < 4.0.0
     typing_extensions
     pyyaml
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,6 +21,7 @@ install_requires =
     fasttext
     torch >= 1.6, < 2.0.0
     transformers >= 3.2.0, < 4.0.0
+    typing_extensions
     pyyaml
 
 [options.entry_points]


### PR DESCRIPTION
(A clone of #14 which suffered a github bug)

**Apart from uploading the models this is ready to merge**

The original intent behind this PR was to make the BERT lexer give its BERT layer inputs that are closer to what it has been trained with and get as much information as possible from its output. Along the way, many other changes have been done where it seemed to make sense or to improve the quality of the word representations.

The changes tend to have a clear positive impact on the parser accuracy. However,  break backward compatibility with the old models in ways that are not easily circumvented, so the models have been retrained (for now only the UD-French-GSD ones)

Notes:

- The FastText embeddings are now trainable by default, which seems to improve the performance slightly when also using a BERT model, but degrades it without. More investigation needed for this and probably hyperparameters tuning too.
- The embeddings of the root in the FastText and BERT embeddings are set to have distributions resembling those of the embedding of non-root words. Since the root token is the most frequent token in the corpus, it could be (and in practice often is)  harmful to e.g. set it to zero. However, the theoretical motivations of the choices made here are flimsy and more investigation in that direction could be beneficial.

## Changed

- The BERT embeddings have undergone drastic changes:
  - BERT is now passed on the full sequence of word pieces, and not the sequence of the first wordpiece of each word
  - The special BOS and EOS tokens are now added, making the input closer to what BERT was trained with
  - The BERT embedding of a word is now either the embedding of its first wordpiece (with the config option `bert_subwords_reduction: "first`, which is also the default if the option is absent) or the mean of the embeddings of its wordpiece (with the config option `bert_subwords_reduction: "mean`).
- Embeddings for the root token have changed in several lexers
  - In the char and FastText lexers, the root token is now considered as a single-character “special” token with a dedicated embedding, in both case trainable. In both lexers, it was previously decomposed in individual characters `"<"`, `"r"`, `"o"`…
  - The BERT part of `BertBaseLexer` now use the unweighted average of the embeddings of all subwords  for the root token.
- FastText embeddings are now *trainable* by default. The old behaviour is available with a config option (see below).
- The FastText embedding of a word is now the mean of the embedding of its subwords instead of the sum, which was making the magnitude of the embedding dependent on the length of the word. Additionally we checked that the padding does not actually enter this mean (since the padding embeddings are kept at zero).
- `BertBaseLexer` and `DefaultLexer` are now responsible for batching and padding their inputs via a `pad_batch` method that returns something acceptable as an input to their `forward` method, making it all transparent from the `DependencyDataset` point of view and allowing a drastic simplification of `DependencyDataset.pad`.
- For all lexers that use it, word dropout is now done in `forward` rather than in tokenization and is now done directly on the tensorized inputs, which is faster, although it has the minor side effect of turning some of the padding into `<unk>`s.
- `DependencyDataset` shuffling and ordering is now done exclusively when building batches and does not affect the internal order, which removes the need to re-encode the trees at every epoch.
- Lexers that use specific unk, pad or root indices or tokens now require them in their constructor instead of statically importing them from `DepTree` or `DependencyDataset`, which helps decouple `deptree` and `lexers` and did not seem to much of a hassle in practice.
- Some functions that used to return bare tuples now return typed namedtuples, which has no other side effect, but improves the typing support and could in the future be used to simplify other parts of the code.
- The biaffine layer is now an actual biaffine layer (with the linear and bias parts) as in the original Dozat and Manning version instead of simply bilinear (the old behaviour is now behind an hyperparameter, see below). It has also been rewritten to be faster and more memory efficient, which somewhat counterbalance the loss of efficiency in the BERT lexer.
- The LSTM encoder now used the somewhat tedious Pytorch `PackSequence` API and effectively ignores the padding instead of having to learn to do so.
- Sentences are no sorted by length at train time anymore and are instead batched in completely random order.

## Removed

- The `cased` hyperparameter for BERT configs is now ignored: uncased BERT tokenizers now lowercase their inputs anyway so we have no need to do it for them and the corner case of using a cased BERT tokenizer while passing it lowercased inputs seems to marginal to keep that code path.
- `FastTextTorch.train_model_from_trees` has been removed, replaced by `FastTextTorch.train_model_from_sents` which takes a list of lists of words instead of a list of trees. The old behaviour can be achieved with `FastTextTorch.train_model_from_sents([tree.words[1:] for tree in traintrees], fasttext_model_path)`.

## Added

- A `freeze_fasttext` boolean hyperparameter that mirrors the `freeze_bert` and can be set to true to disable the fine-tuning of FastText embeddings.
- A `biased_biaffine` boolean hyperparameter that can be set to false to revert to the old behaviour of making the biaffine layer actually simply bilinear.