### PR TITLE
Add the train_models script

### DIFF
--- a/examples/camembert.yaml
+++ b/examples/camembert.yaml
@@ -1,0 +1,22 @@
+# Layer dimensions
+word_embedding_size: 256
+charlstm_output_size: 128
+char_embedding_size: 64
+mlp_input: 1024
+mlp_tag_hidden: 16
+mlp_arc_hidden: 512
+mlp_lab_hidden: 128
+# Training hyperparameters
+encoder_dropout: 0.5
+mlp_dropout: 0.5
+word_dropout: 0.5
+batch_size: 8
+epochs: 64
+lr: 0.00003
+lr_schedule:
+  shape: linear
+  warmup_steps: 100
+# Word embeddings
+lexer: "camembert-base"
+bert_layers: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]
+bert_subwords_reduction: "mean"

--- a/npdependency/conll2018_eval.py
+++ b/npdependency/conll2018_eval.py
@@ -102,9 +102,9 @@ from __future__ import annotations
 import argparse
 import io
 import sys
-from typing import Dict, Optional
 import unicodedata
 import unittest
+from typing import Dict, Optional
 
 # CoNLL-U column names
 ID, FORM, LEMMA, UPOS, XPOS, FEATS, HEAD, DEPREL, DEPS, MISC = range(10)

--- a/npdependency/graph_parser.py
+++ b/npdependency/graph_parser.py
@@ -492,6 +492,7 @@ class BiAffineParser(nn.Module):
     def from_config(
         cls, config_path: Union[str, pathlib.Path], overrides: Dict[str, Any]
     ) -> "BiAffineParser":
+        print(f"Initializing a parser from {config_path}")
         config_path = pathlib.Path(config_path)
         with open(config_path) as in_stream:
             hp = yaml.load(in_stream, Loader=yaml.SafeLoader)

--- a/npdependency/graph_parser.py
+++ b/npdependency/graph_parser.py
@@ -1,34 +1,28 @@
+import argparse
 import math
+import os.path
 import pathlib
+import shutil
 import sys
-from typing import (
-    Any,
-    Callable,
-    Dict,
-    Iterable,
-    List,
-    Sequence,
-    TextIO,
-    Tuple,
-    Union,
-)
 import warnings
-from torch.nn.utils.rnn import pack_padded_sequence, pad_packed_sequence
+from typing import Any, Callable, Dict, Iterable, List, Sequence, TextIO, Tuple, Union
+
+import numpy as np
+import torch
 import transformers
 import yaml
-import argparse
-
-import shutil
-
-import os.path
-import numpy as np
-
-import torch
 from torch import nn
+from torch.nn.utils.rnn import pack_padded_sequence, pad_packed_sequence
+
+from npdependency import conll2018_eval as evaluator
 from npdependency import deptree
-
-from npdependency.mst import chuliu_edmonds_one_root as chuliu_edmonds
-
+from npdependency.deptree import (
+    DependencyBatch,
+    DependencyDataset,
+    DepGraph,
+    gen_labels,
+    gen_tags,
+)
 from npdependency.lexers import (
     BertBaseLexer,
     BertLexerBatch,
@@ -40,14 +34,7 @@ from npdependency.lexers import (
     freeze_module,
     make_vocab,
 )
-from npdependency.deptree import (
-    DependencyBatch,
-    DependencyDataset,
-    DepGraph,
-    gen_labels,
-    gen_tags,
-)
-from npdependency import conll2018_eval as evaluator
+from npdependency.mst import chuliu_edmonds_one_root as chuliu_edmonds
 
 # Python 3.7 shim
 try:

--- a/npdependency/graph_parser.py
+++ b/npdependency/graph_parser.py
@@ -2,6 +2,7 @@ import argparse
 import math
 import os.path
 import pathlib
+import random
 import shutil
 import sys
 import warnings
@@ -603,10 +604,10 @@ def main(argv=None):
         "--pred_file", metavar="PRED_FILE", type=str, help="the conll file to parse"
     )
     parser.add_argument(
-        "--out_dir",
-        metavar="OUT_DIR",
+        "--device",
+        metavar="DEVICE",
         type=str,
-        help="the path of the output directory (defaults to the config dir)",
+        help="the (torch) device to use for the parser. Supersedes configuration if given",
     )
     parser.add_argument(
         "--fasttext",
@@ -614,18 +615,28 @@ def main(argv=None):
         help="The path to either an existing FastText model or a raw text file to train one. If this option is absent, a model will be trained from the parsing train set.",
     )
     parser.add_argument(
-        "--device",
-        metavar="DEVICE",
+        "--out_dir",
+        metavar="OUT_DIR",
         type=str,
-        help="the (torch) device to use for the parser. Supersedes configuration if given",
+        help="the path of the output directory (defaults to the config dir)",
     )
     parser.add_argument(
         "--overwrite",
         action="store_true",
         help="If a model already exists, restart training from scratch instead of continuing.",
     )
+    parser.add_argument(
+        "--rand_seed",
+        metavar="SEED",
+        type=int,
+        help="Force the random seed fo Python and Pytorch (see <https://pytorch.org/docs/stable/notes/randomness.html> for notes on reproducibility)",
+    )
 
     args = parser.parse_args(argv)
+    if args.rand_seed is not None:
+        random.seed(args.rand_seed)
+        torch.manual_seed(args.rand_seed)
+
     if args.device is not None:
         overrides = {"device": args.device}
     else:

--- a/npdependency/graph_parser.py
+++ b/npdependency/graph_parser.py
@@ -585,7 +585,7 @@ def loadlist(filename):
     return strlist
 
 
-def main():
+def main(argv=None):
     parser = argparse.ArgumentParser(
         description="Graph based Attention based dependency parser/tagger"
     )
@@ -624,7 +624,7 @@ def main():
         help="If a model already exists, restart training from scratch instead of continuing.",
     )
 
-    args = parser.parse_args()
+    args = parser.parse_args(argv)
     if args.device is not None:
         overrides = {"device": args.device}
     else:

--- a/npdependency/graph_parser.py
+++ b/npdependency/graph_parser.py
@@ -574,48 +574,6 @@ class BiAffineParser(nn.Module):
         return parser
 
 
-class GridSearch:
-    """ This generates all the possible experiments specified by a yaml config file """
-
-    def __init__(self, yamlparams):
-
-        self.HP = yamlparams
-
-    def generate_setup(self):
-
-        setuplist = []  # init
-        K = list(self.HP.keys())
-        for key in K:
-            value = self.HP[key]
-            if type(value) is list:
-                if setuplist:
-                    setuplist = [elt + [V] for elt in setuplist for V in value]
-                else:
-                    setuplist = [[V] for V in value]
-            else:
-                for elt in setuplist:
-                    elt.append(value)
-        print(f"#{len(setuplist)} runs to be performed")
-
-        for setup in setuplist:
-            yield dict(zip(K, setup))
-
-    @staticmethod
-    def generate_run_name(base_filename, dict_setup):
-        return (
-            base_filename
-            + "+"
-            + "+".join(
-                [
-                    k + ":" + str(v)
-                    for (k, v) in dict_setup.items()
-                    if k != "output_path"
-                ]
-            )
-            + ".conll"
-        )
-
-
 def savelist(strlist, filename):
     with open(filename, "w") as ostream:
         ostream.write("\n".join(strlist))

--- a/npdependency/lexers.py
+++ b/npdependency/lexers.py
@@ -1,23 +1,16 @@
-from typing import (
-    Iterable,
-    List,
-    NamedTuple,
-    Optional,
-    Sequence,
-    TypeVar,
-    Union,
-)
+import os.path
+from collections import Counter
+from tempfile import gettempdir
+from typing import Iterable, List, NamedTuple, Optional, Sequence, TypeVar, Union
+
+import fasttext
 import torch
 import torch.jit
 import transformers
-import fasttext
-import os.path
 from torch import nn
 from torch.nn.utils.rnn import pad_sequence
 from transformers import AutoModel, AutoTokenizer
 from transformers.tokenization_utils_base import BatchEncoding, TokenSpan
-from collections import Counter
-from tempfile import gettempdir
 
 # Python 3.7 shim
 try:

--- a/npdependency/make_summary.py
+++ b/npdependency/make_summary.py
@@ -1,12 +1,10 @@
 import pathlib
-
 from typing import Iterable, List, TextIO
 
 import click
 import click_pathlib
 
 from npdependency import conll2018_eval as evaluator
-
 
 CONLL_METRICS = [
     "Tokens",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,2 +1,6 @@
 [build-system]
 requires = ["setuptools", "wheel"]
+
+[tool.isort]
+profile = "black"
+multi_line_output = 3

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -18,9 +18,10 @@ python scripts/train_models.py {configs_dir} {treebanks_dir} --fasttext {fasttex
 ```
 
 For each `{config_name}.yaml}` file in `{configs_dir}` and each `{treebank_name}` directory in
-`{treebanks_dir}`, this will create a `{out_dir}/{treebank_name}-{config_name}` directory containing
-the trained model and the parsed train and test set. It will also create a summary of the
-performances of the various runs un `{out_dir}/summary.tsv`.
+`{treebanks_dir}` (containing files named `(train|dev|test).conllu`), this will create a
+`{out_dir}/{treebank_name}-{config_name}` directory containing the trained model and the parsed
+train and test set. It will also create a summary of the performances of the various runs un
+`{out_dir}/summary.tsv`.
 
 The `--device` flag is used to specify the devices available to train on as comma-separated list.
 The script runs in a low tech task queue which distributes the train runs among these devices: every

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -14,18 +14,18 @@ error management so if any train run fails it will just hang until you SIGINT or
 After installing npdependency, it can be run with
 
 ```console
-python scripts/train_models.py {configs_dir} {treebanks_dir} --fasttext {fasttext_model} --devices "{device1},{device2},{…}" --out-dir {out_dir}
+python scripts/train_models.py {configs_dir} {treebanks_dir} --args "fasttext={fasttext_model}" --devices "{device1},{device2},{…}" --out-dir {out_dir}
 ```
 
 For each `{config_name}.yaml}` file in `{configs_dir}` and each `{treebank_name}` directory in
-`{treebanks_dir}` (containing files named `(train|dev|test).conllu`), this will create a
+`{treebanks_dir}` (containing files named `/.*(train|dev|test)\.conllu/`), this will create a
 `{out_dir}/{treebank_name}-{config_name}` directory containing the trained model and the parsed
-train and test set. It will also create a summary of the performances of the various runs un
+train and test set. It will also create a summary of the performances of the various runs in
 `{out_dir}/summary.tsv`.
 
 The `--device` flag is used to specify the devices available to train on as comma-separated list.
 The script runs in a rudimentary task queue which distributes the train runs among these devices: every
-run waits until a device is available, then grab it, trains on it and releases it once it is done. 
+run waits until a device is available, then grab it, trains on it and releases it once it is done.
 
 To make several runs happen concurrently on the same device, just specify it several times e.g.
 `--devices "cuda:1,cuda:1"` will maintain two training process on the GPU with index 1. `"cpu"` is

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -24,7 +24,7 @@ train and test set. It will also create a summary of the performances of the var
 `{out_dir}/summary.tsv`.
 
 The `--device` flag is used to specify the devices available to train on as comma-separated list.
-The script runs in a low tech task queue which distributes the train runs among these devices: every
+The script runs in a rudimentary task queue which distributes the train runs among these devices: every
 run waits until a device is available, then grab it, trains on it and releases it once it is done. 
 
 To make several runs happen concurrently on the same device, just specify it several times e.g.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,32 @@
+Utility scripts
+===============
+
+This contains utility scripts that are not part of the parser but make its usage easier.
+
+
+## `train_models.py`: training a treebank×configs matrix
+
+`train_models.py` is an utility to train and evaluate models using several configs on several
+treebanks. We use it internally to train the models we provide and it is not much more flexible than
+we need it to be for that purpose (but PR to improve that are welcome). It also has very little
+error management so if any train run fails it will just hang until you SIGINT or SIGKILL it.
+
+After installing npdependency, it can be run with
+
+```console
+python scripts/train_models.py {configs_dir} {treebanks_dir} --fasttext {fasttext_model} --devices "{device1},{device2},{…}" --out-dir {out_dir}
+```
+
+For each `{config_name}.yaml}` file in `{configs_dir}` and each `{treebank_name}` directory in
+`{treebanks_dir}`, this will create a `{out_dir}/{treebank_name}-{config_name}` directory containing
+the trained model and the parsed train and test set. It will also create a summary of the
+performances of the various runs un `{out_dir}/summary.tsv`.
+
+The `--device` flag is used to specify the devices available to train on as comma-separated list.
+The script runs in a low tech task queue which distributes the train runs among these devices: every
+run waits until a device is available, then grab it, trains on it and releases it once it is done. 
+
+To make several runs happen concurrently on the same device, just specify it several times e.g.
+`--devices "cuda:1,cuda:1"` will maintain two training process on the GPU with index 1. `"cpu"` is
+of course an acceptable device that you can also specify several times and mix with GPU devices, so
+this doesn't require access to GPUs.

--- a/scripts/train_models.py
+++ b/scripts/train_models.py
@@ -158,4 +158,5 @@ def main(
 
 
 if __name__ == "__main__":
+    multiprocessing.set_start_method("spawn")
     main()

--- a/scripts/train_models.py
+++ b/scripts/train_models.py
@@ -158,7 +158,7 @@ def main(
     summary_file = out_dir / "summary.tsv"
     if not summary_file.exists():
         summary_file.write_text("run\tdev UPOS\tdev LAS\ttest UPOS\ttest LAS\n")
-    with open(summary_file, "wa") as out_stream:
+    with open(summary_file, "a") as out_stream:
         for name, scores in res:
             out_stream.write(
                 f"{name}\t{100*scores.dev_upos:.2f}\t{100*scores.dev_las:.2f}\t{100*scores.test_upos:.2f}\t{100*scores.test_las:.2f}\n"

--- a/scripts/train_models.py
+++ b/scripts/train_models.py
@@ -123,7 +123,7 @@ def run_multi(
 @click.option("--prefix", default="", help="A custom prefix to prepend to run names.")
 @click.option(
     "--rand-seeds",
-    callback=(lambda _ctx, _opt, val: [int(s) for s in val.split(",")]),
+    callback=(lambda _ctx, _opt, val: None if val is None else [int(s) for s in val.split(",")]),
     help="A comma-separated list of random seeds to try",
 )
 def main(
@@ -196,6 +196,7 @@ def main(
             out_stream.write(
                 f"{name}\t{100*scores.dev_upos:.2f}\t{100*scores.dev_las:.2f}\t{100*scores.test_upos:.2f}\t{100*scores.test_las:.2f}\n"
             )
+    # TODO: stats aggregated across random seeds computed here
 
 
 if __name__ == "__main__":

--- a/scripts/train_models.py
+++ b/scripts/train_models.py
@@ -127,7 +127,7 @@ def main(
 ):
     out_dir.mkdir(parents=True, exist_ok=True)
     treebanks = [train.parent for train in treebanks_dir.glob("**/train.conllu")]
-    configs = configs_dir.glob("*.yaml")
+    configs = list(configs_dir.glob("*.yaml"))
     additional_args = dict()
     if fasttext is not None:
         additional_args["fasttext"] = str(fasttext)

--- a/scripts/train_models.py
+++ b/scripts/train_models.py
@@ -1,0 +1,158 @@
+import multiprocessing
+import pathlib
+from typing import Any, Dict, Iterable, List, NamedTuple, Optional, Tuple
+import click
+
+import click_pathlib
+
+from npdependency import graph_parser
+from npdependency import conll2018_eval as evaluator
+
+
+class TrainResults(NamedTuple):
+    dev_upos: float
+    dev_las: float
+    test_upos: float
+    test_las: float
+
+
+def train_single_model(
+    train_file: pathlib.Path,
+    dev_file: pathlib.Path,
+    pred_file: pathlib.Path,
+    out_dir: pathlib.Path,
+    config_path: pathlib.Path,
+    device: str,
+    additional_args: Dict[str, str],
+) -> TrainResults:
+    graph_parser.main(
+        [
+            "--train_file",
+            str(train_file),
+            "--dev_file",
+            str(dev_file),
+            "--pred_file",
+            str(pred_file),
+            "--out_dir",
+            str(out_dir),
+            "--device",
+            device,
+            *(a for key, value in additional_args.items() for a in (f"--{key}", value)),
+            str(config_path),
+        ],
+    )
+
+    gold_devset = evaluator.load_conllu_file(dev_file)
+    syst_devset = evaluator.load_conllu_file(out_dir / f"{dev_file.name}.parsed")
+    dev_metrics = evaluator.evaluate(gold_devset, syst_devset)
+
+    gold_testset = evaluator.load_conllu_file(pred_file)
+    syst_testset = evaluator.load_conllu_file(out_dir / f"{pred_file.name}.parsed")
+    test_metrics = evaluator.evaluate(gold_testset, syst_testset)
+
+    return TrainResults(
+        dev_upos=dev_metrics["UPOS"].f1,
+        dev_las=dev_metrics["LAS"].f1,
+        test_upos=test_metrics["UPOS"].f1,
+        test_las=test_metrics["LAS"].f1,
+    )
+
+
+# It would be nice to be able to have this as a closure, but unfortunately it doesn't work since
+# closures are not picklable and multiprocessing can only deal with picklable workers
+def worker(device_queue, name, kwargs) -> Tuple[str, TrainResults]:
+    # We use no more workers than devices so the queue should never be empty when spawning a
+    # worker and we don't need to block here
+    device = device_queue.get()
+    kwargs["device"] = device
+    print(f"Start training {name} on {device}")
+    res = train_single_model(**kwargs)
+    device_queue.put(device)
+    print(f"Run {name} finished with results {res}")
+    return (name, res)
+
+
+def run_multi(
+    runs: Iterable[Tuple[str, Dict[str, Any]]], devices: List[str]
+) -> List[Tuple[str, TrainResults]]:
+    manager = multiprocessing.Manager()
+    device_queue = manager.Queue()
+    for d in devices:
+        device_queue.put(d)
+
+    with multiprocessing.Pool(len(devices)) as pool:
+        res = pool.starmap(worker, ((device_queue, *r) for r in runs))
+
+    return res
+
+
+@click.command()
+@click.argument(
+    "configs_dir",
+    type=click_pathlib.Path(resolve_path=True, exists=True, file_okay=False),
+)
+@click.argument(
+    "treebanks_dir",
+    type=click_pathlib.Path(resolve_path=True, exists=True, file_okay=False),
+)
+@click.option(
+    "--out-dir",
+    default=".",
+    type=click_pathlib.Path(resolve_path=True, exists=False, file_okay=False),
+)
+@click.option(
+    "--devices",
+    "devices",
+    default="cpu",
+    callback=(lambda _ctx, _opt, val: val.split(",")),
+    help="A comma-separated list of devices to run on.",
+)
+@click.option(
+    "--fasttext-path",
+    "fasttext",
+    type=click_pathlib.Path(resolve_path=True, exists=True, dir_okay=False),
+    help="The path to a pretrained FastText model",
+)
+def main(
+    configs_dir: pathlib.Path,
+    out_dir: pathlib.Path,
+    treebanks_dir: pathlib.Path,
+    devices: List[str],
+    fasttext: Optional[pathlib.Path],
+):
+    out_dir.mkdir(parents=True, exist_ok=True)
+    treebanks = [train.parent for train in treebanks_dir.glob("**/train.conllu")]
+    configs = configs_dir.glob("*.yaml")
+    additional_args = dict()
+    if fasttext is not None:
+        additional_args["fasttext"] = str(fasttext)
+    runs: List[Tuple[str, Dict[str, Any]]] = []
+    for c in configs:
+        for t in treebanks:
+            run_name = f"{t.name}-{c.stem}"
+            runs.append(
+                (
+                    run_name,
+                    {
+                        "train_file": t / "train.conllu",
+                        "dev_file": t / "dev.conllu",
+                        "pred_file": t / "test.conllu",
+                        "out_dir": out_dir / run_name,
+                        "config_path": c,
+                        "additional_args": additional_args,
+                    },
+                )
+            )
+
+    res = run_multi(runs, devices)
+
+    with open(out_dir / "summary.tsv", "w") as out_stream:
+        out_stream.write("run\tdev UPOS\tdev LAS\ttest UPOS\ttest LAS\n")
+        for name, scores in res:
+            out_stream.write(
+                f"{name}\t{100*scores.dev_upos:.2f}\t{100*scores.dev_las:.2f}\t{100*scores.test_upos:.2f}\t{100*scores.test_las:.2f}\n"
+            )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/train_models.py
+++ b/scripts/train_models.py
@@ -177,7 +177,7 @@ def main(
             *(args if args is not None else []),
         ]
     additional_args_combinations: List[Dict[str, str]]
-    if args is not None:
+    if args:
         args_names, all_args_values = map(list, zip(*args))
         additional_args_combinations = [
             dict(zip(args_names, args_values))

--- a/scripts/train_models.py
+++ b/scripts/train_models.py
@@ -1,11 +1,11 @@
 import multiprocessing
 import pathlib
+import subprocess
 from typing import Any, Dict, Iterable, List, NamedTuple, Optional, Tuple
 import click
 
 import click_pathlib
 
-from npdependency import graph_parser
 from npdependency import conll2018_eval as evaluator
 
 
@@ -25,8 +25,9 @@ def train_single_model(
     device: str,
     additional_args: Dict[str, str],
 ) -> TrainResults:
-    graph_parser.main(
+    subprocess.run(
         [
+            "graph_parser",
             "--train_file",
             str(train_file),
             "--dev_file",
@@ -40,6 +41,7 @@ def train_single_model(
             *(a for key, value in additional_args.items() for a in (f"--{key}", value)),
             str(config_path),
         ],
+        check=True
     )
 
     gold_devset = evaluator.load_conllu_file(dev_file)
@@ -158,5 +160,4 @@ def main(
 
 
 if __name__ == "__main__":
-    multiprocessing.set_start_method("spawn")
     main()

--- a/scripts/train_models.py
+++ b/scripts/train_models.py
@@ -66,7 +66,10 @@ def worker(device_queue, name, kwargs) -> Tuple[str, TrainResults]:
     device = device_queue.get()
     kwargs["device"] = device
     print(f"Start training {name} on {device}")
-    res = train_single_model(**kwargs)
+    try:
+        res = train_single_model(**kwargs)
+    except Exception as e:
+        raise Exception(e.message)
     device_queue.put(device)
     print(f"Run {name} finished with results {res}")
     return (name, res)
@@ -81,7 +84,10 @@ def run_multi(
         device_queue.put(d)
 
     with multiprocessing.Pool(len(devices)) as pool:
-        res = pool.starmap(worker, ((device_queue, *r) for r in runs))
+        try:
+            res = pool.starmap(worker, ((device_queue, *r) for r in runs))
+        except Exception as e:
+            raise e
 
     return res
 


### PR DESCRIPTION
This adds a script to help train multiple models in batch, with a rudimentary task scheduling application (you can specify a device and the number of runs it supports concurrently), this is meant to help us regenerate our pretrained models, but it can also be used to help searching for hyperparameters.

Once npdependency is cloned and installed, the script should be run as

```console
python scripts/train_models.py {configs_dir} {treebanks_dir} --args "fasttext={fasttext_model}" --devices "{device1},{device2},{…}" --out-dir {out_dir}
```

(omit the `--args …` part if you don't want to use FastText).