### PR TITLE
Parse from raw (CLI refactor part 1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,14 +38,17 @@ in `setup.cfg` and call `python -m npdependency.graph_parser3` directly from the
 ## Parsing task
 
 The parsing task (or prediction task) assumes you have an already trained model in the directory
-MODEL. You can parse a file FILE in truncated CONLL-U format with the command:
+MODEL. You can parse a file INPUT_FILE in truncated CONLL-U format with the command:
 
 ```sh
-graph_parser  --pred_file FILE   MODEL/params.yaml
+hopsparser parse MODEL/params.yaml INPUT_FILE OUTPUT_FILE
 ```
 
-This results in a parsed file called `FILE.parsed`. The `MODEL/params.yaml` is the model
-hyperparameters file. The `FILE` argument is supposed to be the path to a file in the
+This results in a parsed file called `OUTPUT_FILE`. The `MODEL/params.yaml` is the model
+hyperparameters file. Both INPUT_FILE and OUTPUT_FILE can be set to `-` to use the standard i/o
+streams, which can be convenient if you want to use the parser in a pipe.
+
+The `INPUT_FILE` argument is supposed to be the path to a file in the
 [CONLL-U](https://universaldependencies.org/format.html) format, possibly with missing columns. For
 instance:
 
@@ -60,6 +63,9 @@ instance:
 
 That is we require word indexation and word forms only. Empty words are currently not supported.
 Multi-word tokens are not taken into account by the parsing models but are preserved in the outputs.
+
+Alternatively, you may add the `--raw` flag to the command above, in which case the parser expects a
+pre-tokenized raw text file with one sentence per line and individual tokens separated by blanks.
 
 Depending on the model, the parser will be more or less fast and more or less accurate. We can
 however expect the parser to process several hundred sentences per second with a decent GPU. The GPU

--- a/npdependency/deptree.py
+++ b/npdependency/deptree.py
@@ -359,8 +359,8 @@ class DependencyDataset:
         lexer: lexers.Lexer,
         char_dataset: lexers.CharDataSet,
         ft_dataset: lexers.FastTextDataSet,
-        use_labels: Optional[List[str]] = None,
-        use_tags: Optional[List[str]] = None,
+        use_labels: Optional[Sequence[str]] = None,
+        use_tags: Optional[Sequence[str]] = None,
     ):
         self.lexer = lexer
         self.char_dataset = char_dataset

--- a/npdependency/deptree.py
+++ b/npdependency/deptree.py
@@ -2,13 +2,13 @@ import pathlib
 from random import shuffle
 from typing import (
     Dict,
+    IO,
     Iterable,
     List,
     NamedTuple,
     Optional,
     Sequence,
     Set,
-    TextIO,
     TypeVar,
     Union,
 )
@@ -197,7 +197,7 @@ class DepGraph:
         return self.gap_degree() == 0
 
     @classmethod
-    def read_tree(cls, istream: TextIO) -> Optional["DepGraph"]:
+    def read_tree(cls, istream: IO[str]) -> Optional["DepGraph"]:
         """
         Reads a conll tree from input stream
         """
@@ -220,7 +220,7 @@ class DepGraph:
         edges = []
         for dataline in conll:
             if len(dataline) < 10:  # pads the dataline
-                dataline.extend(["-"] * (10 - len(dataline)))
+                dataline.extend(["_"] * (10 - len(dataline)))
                 dataline[6] = "0"
 
             if "-" in dataline[0]:
@@ -231,9 +231,7 @@ class DepGraph:
                 words.append(dataline[1])
                 if dataline[3] not in ["-", "_"]:
                     postags.append(dataline[3])
-                if dataline[6] != "0":  # do not add root immediately
-                    # shift indexes !
-                    edges.append(Edge(int(dataline[6]), dataline[7], int(dataline[0])))
+                edges.append(Edge(int(dataline[6]), dataline[7], int(dataline[0])))
         return cls(
             edges,
             words,
@@ -338,7 +336,8 @@ class DependencyDataset:
 
     @staticmethod
     def read_conll(
-        filename: Union[str, pathlib.Path], max_tree_length: Optional[int] = None
+        filename: Union[str, pathlib.Path, IO[str]],
+        max_tree_length: Optional[int] = None,
     ) -> List[DepGraph]:
         print(f"Reading treebank from {filename}")
         with smart_open(filename) as istream:

--- a/npdependency/deptree.py
+++ b/npdependency/deptree.py
@@ -19,6 +19,7 @@ from typing_extensions import Final
 
 from npdependency import lexers
 from npdependency.lexers import BertLexerBatch, BertLexerSentence
+from npdependency.utils import smart_open
 
 
 class MWERange(NamedTuple):
@@ -340,7 +341,7 @@ class DependencyDataset:
         filename: Union[str, pathlib.Path], max_tree_length: Optional[int] = None
     ) -> List[DepGraph]:
         print(f"Reading treebank from {filename}")
-        with open(filename) as istream:
+        with smart_open(filename) as istream:
             treelist = []
             tree = DepGraph.read_tree(istream)
             while tree:

--- a/npdependency/graph_parser.py
+++ b/npdependency/graph_parser.py
@@ -10,13 +10,14 @@ from typing import (
     Any,
     Callable,
     Dict,
+    IO,
     Iterable,
     List,
     Optional,
     Sequence,
-    TextIO,
     Tuple,
     Union,
+    cast,
 )
 
 import numpy as np
@@ -429,7 +430,7 @@ class BiAffineParser(nn.Module):
     def predict_batch(
         self,
         test_set: DependencyDataset,
-        ostream: TextIO,
+        ostream: IO[str],
         batch_size: int,
         greedy: bool = False,
     ):
@@ -601,8 +602,8 @@ def loadlist(filename):
 
 def parse(
     config_file: Union[str, pathlib.Path],
-    in_file: Union[str, pathlib.Path, TextIO],
-    out_file: Union[str, pathlib.Path, TextIO],
+    in_file: Union[str, pathlib.Path, IO[str]],
+    out_file: Union[str, pathlib.Path, IO[str]],
     overrides: Optional[Dict[str, str]] = None,
 ):
     if overrides is None:
@@ -624,7 +625,9 @@ def parse(
         use_tags=parser.tagset,
     )
     with smart_open(out_file, "w") as ostream:
-        parser.predict_batch(testset, ostream, hp["batch_size"], greedy=False)
+        parser.predict_batch(
+            testset, cast(IO[str], ostream), hp["batch_size"], greedy=False
+        )
 
 
 def main(argv=None):

--- a/npdependency/main.py
+++ b/npdependency/main.py
@@ -1,0 +1,61 @@
+import pathlib
+import sys
+from typing import TextIO, Union
+
+import click
+import click_pathlib
+
+from npdependency import graph_parser
+
+
+@click.group()
+def cli():
+    pass
+
+
+@cli.command()
+@click.argument(
+    "config_path",
+    type=click_pathlib.Path(resolve_path=True, exists=True, dir_okay=False),
+)
+@click.argument(
+    "input_path",
+    type=click.Path(resolve_path=True, exists=True, dir_okay=False, allow_dash=True),
+)
+@click.argument(
+    "output_path",
+    type=click.Path(resolve_path=True, dir_okay=False, writable=True, allow_dash=True),
+    default="-",
+)
+@click.option(
+    "--device", default="cpu", help="The device to use for parsing. (cpu, gpu:0, …)."
+)
+@click.option(
+    "--tokenize", is_flag=True, help="Pass this if the input has to be tokenized."
+)
+def parse(
+    config_path: pathlib.Path,
+    input_path: str,
+    output_path: str,
+    device: str,
+    tokenize: bool,
+):
+    input_file: Union[TextIO, str]
+    if input_path == "-":
+        input_file = sys.stdin
+    else:
+        input_file = input_path
+
+    output_file: Union[TextIO, str]
+    if output_path == "-":
+        output_file = sys.stdout
+    else:
+        output_file = output_path
+
+    graph_parser.parse(
+        config_path, input_file, output_file, overrides={"device": device}
+    )
+
+
+if __name__ == "__main__":
+    cli()

--- a/npdependency/utils.py
+++ b/npdependency/utils.py
@@ -1,0 +1,35 @@
+import contextlib
+import pathlib
+import sys
+from typing import cast, IO, Union
+
+
+@contextlib.contextmanager
+def smart_open(f: Union[pathlib.Path, str, IO], mode: str = "r", *args, **kwargs):
+    """Open files, paths and i/o streams transparently."""
+    fh: IO
+    if f == "-":
+        if "r" in mode:
+            stream = sys.stdin
+        else:
+            stream = sys.stdout
+        if "b" in mode:
+            fh = stream.buffer
+        else:
+            fh = stream
+        close = False
+    elif hasattr(f, "write") or hasattr(f, "read"):
+        fh = cast(IO, f)
+        close = False
+    else:
+        fh = open(cast(Union[pathlib.Path, str], f), mode, *args, **kwargs)
+        close = True
+
+    try:
+        yield fh
+    finally:
+        if close:
+            try:
+                fh.close()
+            except AttributeError:
+                pass

--- a/npdependency/utils.py
+++ b/npdependency/utils.py
@@ -1,11 +1,13 @@
 import contextlib
 import pathlib
 import sys
-from typing import cast, IO, Union
+from typing import Generator, cast, IO, Union
 
 
 @contextlib.contextmanager
-def smart_open(f: Union[pathlib.Path, str, IO], mode: str = "r", *args, **kwargs):
+def smart_open(
+    f: Union[pathlib.Path, str, IO], mode: str = "r", *args, **kwargs
+) -> Generator[IO, None, None]:
     """Open files, paths and i/o streams transparently."""
     fh: IO
     if f == "-":

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,6 +26,7 @@ install_requires =
 
 [options.entry_points]
 console_scripts =
+    hopsparser = npdependency.main:cli
     graph_parser = npdependency.graph_parser:main
     make_parser_csv_summary = npdependency.make_summary:make_csv_summary
     eval_parse = npdependency.conll2018_eval:main

--- a/tox.ini
+++ b/tox.ini
@@ -4,8 +4,11 @@ envlist = py39, py38, py37
 skip_missing_interpreters = true
 
 [testenv]
+allowlist_externals=cmp
 commands =
     graph_parser --train_file tests/fixtures/truncated-sv_talbanken-ud-dev.conllu --dev_file tests/fixtures/truncated-sv_talbanken-ud-dev.conllu --pred_file tests/fixtures/truncated-sv_talbanken-ud-dev.conllu --out_dir {envtmpdir}/nobert-smoketest-output tests/fixtures/toy_nobert.yaml
+    hopsparser parse {envtmpdir}/nobert-smoketest-output/model/toy_nobert.yaml tests/fixtures/truncated-sv_talbanken-ud-dev.conllu {envtmpdir}/nobert-smoketest-output/truncated-sv_talbanken-ud-dev.conllu.parsed2
+    cmp {envtmpdir}/nobert-smoketest-output/truncated-sv_talbanken-ud-dev.conllu.parsed2 {envtmpdir}/nobert-smoketest-output/truncated-sv_talbanken-ud-dev.conllu.parsed
     eval_parse -v tests/fixtures/truncated-sv_talbanken-ud-dev.conllu {envtmpdir}/nobert-smoketest-output/truncated-sv_talbanken-ud-dev.conllu.parsed
     graph_parser --train_file tests/fixtures/truncated-sv_talbanken-ud-dev.conllu --dev_file tests/fixtures/truncated-sv_talbanken-ud-dev.conllu --pred_file tests/fixtures/truncated-sv_talbanken-ud-dev.conllu --out_dir {envtmpdir}/flaubert-smoketest-output tests/fixtures/toy_flaubert.yaml
     eval_parse -v tests/fixtures/truncated-sv_talbanken-ud-dev.conllu {envtmpdir}/flaubert-smoketest-output/truncated-sv_talbanken-ud-dev.conllu.parsed


### PR DESCRIPTION
This is the first step in refactoring the command line interface: it moves the inference task to a new console entry point `hopsparser`, where we will progressively move the existing command line functions (and add new ones).
The old `graph_parser` interface is still available and will stay at least until we have feature parity.

## Added

- A new console entry point `hopsparser`, for now with only one command `parse` that parse a file, either from raw (one sentence per line, pre-tokenized with blanks) or from an incomplete CoNLL-U file.