### PR TITLE
Preserve the columns we don't predict

### DIFF
--- a/npdependency/deptree.py
+++ b/npdependency/deptree.py
@@ -58,8 +58,8 @@ class DepGraph:
     def __init__(
         self,
         edges: Iterable[Edge],
-        wordlist: Optional[Iterable[str]] = None,
-        pos_tags: Optional[Iterable[str]] = None,
+        wordlist: Iterable[str],
+        pos_tags: Iterable[str],
         with_root: bool = False,
         mwe_ranges: Optional[Iterable[MWERange]] = None,
         metadata: Optional[Iterable[str]] = None,
@@ -74,11 +74,8 @@ class DepGraph:
         if with_root:
             self.add_root()
 
-        self.words = [self.ROOT_TOKEN, *(wordlist if wordlist is not None else [])]
-        self.pos_tags = [
-            self.ROOT_TOKEN,
-            *(pos_tags if pos_tags is not None else []),
-        ]
+        self.words = [self.ROOT_TOKEN, *wordlist]
+        self.pos_tags = [self.ROOT_TOKEN, *pos_tags]
         self.mwe_ranges = [] if mwe_ranges is None else mwe_ranges
         self.metadata = [] if metadata is None else metadata
 
@@ -172,8 +169,7 @@ class DepGraph:
                 misc=cols[9],
             )
             words.append(node.form)
-            if node.upos != "_":
-                postags.append(node.upos)
+            postags.append(node.upos)
             edges.append(Edge(node.head, node.deprel, node.identifier))
         return cls(
             edges,

--- a/npdependency/deptree.py
+++ b/npdependency/deptree.py
@@ -66,17 +66,21 @@ class DepGraph:
         self.nodes = list(nodes)
 
         govs = {n.identifier: n.head for n in self.nodes}
-
         if 0 not in govs.values():
             raise ValueError("Malformed tree: no root")
-
         if len(set(govs.values()).difference(govs.keys())) > 1:
             raise ValueError("Malformed tree: non-connex")
 
-        self.words = [self.ROOT_TOKEN, *(n.form for n in self.nodes)]
-        self.pos_tags = [self.ROOT_TOKEN, *(n.upos for n in self.nodes)]
         self.mwe_ranges = [] if mwe_ranges is None else list(mwe_ranges)
         self.metadata = [] if metadata is None else list(metadata)
+    
+    @property
+    def words(self) -> List[str]:
+        return [self.ROOT_TOKEN, *(n.form for n in self.nodes)]
+
+    @property
+    def pos_tags(self) -> List[str]:
+        return [self.ROOT_TOKEN, *(n.upos for n in self.nodes)]
 
     def get_all_edges(self) -> List[Edge]:
         """
@@ -317,8 +321,6 @@ class DependencyDataset:
         self.encode()
 
     def encode(self):
-        # NOTE: we mask the ROOT token features with the label padding that will be ignored by
-        # crossentropy, it's not very satisfying though, maybe hardcode it in (lab|tag)toi ?
         self.encoded_words, self.heads, self.labels, self.tags = [], [], [], []
 
         for tree in self.treelist:

--- a/npdependency/deptree.py
+++ b/npdependency/deptree.py
@@ -266,7 +266,8 @@ class DependencyDataset:
     PAD_IDX: Final[int] = 0
     PAD_TOKEN: Final[str] = "<pad>"
     UNK_WORD: Final[str] = "<unk>"
-    # Labels that are -100 are ignored in torch crossentropy
+    # Labels that are -100 are ignored in torch crossentropy (we still set it explicitely in
+    # `graph_parser`)
     LABEL_PADDING: Final[int] = -100
 
     @staticmethod
@@ -278,6 +279,8 @@ class DependencyDataset:
         with smart_open(filename) as istream:
             trees = []
             current_tree_lines: List[str] = []
+            # Add a dummy empty line to flush the last tree even if the CoNLL-U mandatory empty last
+            # line is absent
             for line in (*istream, ""):
                 if not line or line.isspace():
                     if current_tree_lines:

--- a/npdependency/deptree.py
+++ b/npdependency/deptree.py
@@ -1,3 +1,4 @@
+from dataclasses import dataclass
 import pathlib
 from random import shuffle
 from typing import (
@@ -35,6 +36,20 @@ class Edge(NamedTuple):
     gov: int
     label: str
     dep: int
+
+
+@dataclass(eq=False)
+class DepNode:
+    identifier: int
+    form: str
+    lemma: str
+    upos: str
+    xpos: str
+    feats: str
+    head: int
+    deprel: str
+    deps: str
+    misc: str
 
 
 class DepGraph:
@@ -117,23 +132,6 @@ class DepGraph:
         """
         self.gov2dep.setdefault(edge.gov, []).append(edge)
         self.has_gov.add(edge.dep)
-
-    def span(self, gov: int) -> Set[int]:
-        """
-        Returns the list of nodes in the yield of this node
-        the set of j such that (i -*> j).
-        """
-        agenda = [gov]
-        closure = set([gov])
-        while agenda:
-            node = agenda.pop()
-            if node in self.gov2dep:
-                succ = [edge.dep for edge in self.gov2dep[node]]
-            else:
-                succ = []
-            agenda.extend([node for node in succ if node not in closure])
-            closure.update(succ)
-        return closure
 
     @classmethod
     def read_tree(cls, istream: IO[str]) -> Optional["DepGraph"]:

--- a/npdependency/graph_parser.py
+++ b/npdependency/graph_parser.py
@@ -495,12 +495,9 @@ class BiAffineParser(nn.Module):
                         )
                     ]
                     out_trees.append(
-                        DepGraph(
-                            edges[1:],
-                            wordlist=tree.words[1:],
+                        tree.replace(
+                            edges=edges[1:],
                             pos_tags=pos_tags[1:],
-                            mwe_ranges=tree.mwe_ranges,
-                            metadata=tree.metadata,
                         )
                     )
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,7 +21,8 @@ install_requires =
     fastapi
     fasttext
     pyyaml
-    torch >= 1.6, < 2.0.0
+    torch >= 1.6, < 2.0.0 ; python_version<="3.8"
+    torch >= 1.8, < 2.0.0 ; python_version>="3.9"
     transformers >= 4.0.0, < 5.0.0
     typing_extensions
     uvicorn

--- a/tests/fixtures/raw.txt
+++ b/tests/fixtures/raw.txt
@@ -1,0 +1,2 @@
+Je reconnais l' existence du kiwi .
+Jag känner hen

--- a/tox.ini
+++ b/tox.ini
@@ -9,6 +9,7 @@ commands =
     graph_parser --train_file tests/fixtures/truncated-sv_talbanken-ud-dev.conllu --dev_file tests/fixtures/truncated-sv_talbanken-ud-dev.conllu --pred_file tests/fixtures/truncated-sv_talbanken-ud-dev.conllu --out_dir {envtmpdir}/nobert-smoketest-output tests/fixtures/toy_nobert.yaml
     hopsparser parse {envtmpdir}/nobert-smoketest-output/model/toy_nobert.yaml tests/fixtures/truncated-sv_talbanken-ud-dev.conllu {envtmpdir}/nobert-smoketest-output/truncated-sv_talbanken-ud-dev.conllu.parsed2
     cmp {envtmpdir}/nobert-smoketest-output/truncated-sv_talbanken-ud-dev.conllu.parsed2 {envtmpdir}/nobert-smoketest-output/truncated-sv_talbanken-ud-dev.conllu.parsed
+    hopsparser parse --raw {envtmpdir}/nobert-smoketest-output/model/toy_nobert.yaml tests/fixtures/raw.txt {envtmpdir}/nobert-smoketest-output/raw.conllu.parsed2
     eval_parse -v tests/fixtures/truncated-sv_talbanken-ud-dev.conllu {envtmpdir}/nobert-smoketest-output/truncated-sv_talbanken-ud-dev.conllu.parsed
     graph_parser --train_file tests/fixtures/truncated-sv_talbanken-ud-dev.conllu --dev_file tests/fixtures/truncated-sv_talbanken-ud-dev.conllu --pred_file tests/fixtures/truncated-sv_talbanken-ud-dev.conllu --out_dir {envtmpdir}/flaubert-smoketest-output tests/fixtures/toy_flaubert.yaml
     eval_parse -v tests/fixtures/truncated-sv_talbanken-ud-dev.conllu {envtmpdir}/flaubert-smoketest-output/truncated-sv_talbanken-ud-dev.conllu.parsed


### PR DESCRIPTION
Currently, when outputting a result, we only fill the ID, FORM, UPOS, HEAD and DEPREL columns. If the input is a CoNLL-U file with data in the other columns, these are not preserved in the output.

This PR fixes this, through a complete refactor of the `DepGraph` class, which now internally preserves a list of CoNLL nodes, wrapped by getters to continue providing the previous API. Library 

## Breaking

- Significant refactor of the `DepGraph` class that breaks library compatibility (however to the best of my knowledge, no one use this project in library mode so that should not be a big deal 😄)

## Changed

- CoNLL-U columns present in the input of the parsing methods that are not predicted by the parser are now preserved in the output.