### PR TITLE
Improve pretrained API

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,10 +14,10 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@v1
-            - name: Set up Python 3.8
+            - name: Set up Python 3.9
               uses: actions/setup-python@v2
               with:
-                  python-version: 3.8
+                  python-version: 3.9
             - name: Install dependencies
               run: |
                   python -m pip install --upgrade pip wheel setuptools
@@ -35,7 +35,7 @@ jobs:
         strategy:
             max-parallel: 4
             matrix:
-                python-version: [3.7, 3.8]
+                python-version: [3.7, 3.8, 3.9]
         steps:
             - uses: actions/checkout@v1
             - name: Set up Python ${{ matrix.python-version }}
@@ -61,7 +61,7 @@ jobs:
             - name: Install Python
               uses: actions/setup-python@v2
               with:
-                  python-version: "3.8"
+                  python-version: "3.9"
             - name: Install dependencies
               run: python -m pip install --upgrade pip setuptools wheel build
             - name: Build wheels
@@ -78,7 +78,7 @@ jobs:
             - uses: actions/setup-python@v2
               name: Install Python
               with:
-                  python-version: "3.8"
+                  python-version: "3.9"
             - name: Install dependencies
               run: python -m pip install --upgrade pip setuptools wheel build
             - name: Build wheels

--- a/npdependency/deptree.py
+++ b/npdependency/deptree.py
@@ -302,13 +302,13 @@ class DependencyDataset:
         self,
         treelist: List[DepGraph],
         lexer: lexers.Lexer,
-        char_dataset: lexers.CharDataSet,
+        chars_lexer: lexers.CharRNNLexer,
         ft_lexer: lexers.FastTextLexer,
         use_labels: Optional[Sequence[str]] = None,
         use_tags: Optional[Sequence[str]] = None,
     ):
         self.lexer = lexer
-        self.char_dataset = char_dataset
+        self.chars_lexer = chars_lexer
         self.ft_lexer = ft_lexer
         self.treelist = treelist
         if use_labels:
@@ -327,6 +327,9 @@ class DependencyDataset:
         self.tags: List[List[int]] = []
         self.encode()
 
+    # FIXME: this is inconsistent: we encode the words but not the chars or the ft subwords it would
+    # be better to do it here, replace encoded_words by an encoded_trees that contain the encodeings
+    # for all the lexers?
     def encode(self):
         self.encoded_words, self.heads, self.labels, self.tags = [], [], [], []
 
@@ -371,7 +374,7 @@ class DependencyDataset:
             batch_indices = order[i : i + batch_size]
             trees = tuple(self.treelist[j] for j in batch_indices)
 
-            chars = tuple(self.char_dataset.batch_chars([t.words for t in trees]))
+            chars = tuple(self.chars_lexer.batch_chars([t.words for t in trees]))
             encoded_words = self.lexer.pad_batch([self.encoded_words[j] for j in batch_indices])  # type: ignore
             heads = self.pad(
                 [self.heads[j] for j in batch_indices], padding_value=self.LABEL_PADDING

--- a/npdependency/deptree.py
+++ b/npdependency/deptree.py
@@ -303,13 +303,13 @@ class DependencyDataset:
         treelist: List[DepGraph],
         lexer: lexers.Lexer,
         char_dataset: lexers.CharDataSet,
-        ft_dataset: lexers.FastTextDataSet,
+        ft_lexer: lexers.FastTextLexer,
         use_labels: Optional[Sequence[str]] = None,
         use_tags: Optional[Sequence[str]] = None,
     ):
         self.lexer = lexer
         self.char_dataset = char_dataset
-        self.ft_dataset = ft_dataset
+        self.ft_lexer = ft_lexer
         self.treelist = treelist
         if use_labels:
             self.itolab = use_labels
@@ -384,7 +384,7 @@ class DependencyDataset:
             # `torch.arange(sent_lengths.max()).unsqueeze(0).lt(sent_lengths.unsqueeze(1).logical_and(torch.arange(sent_lengths.max()).gt(0))`
             content_mask = labels.ne(self.LABEL_PADDING)
             sent_lengths = torch.tensor([len(t) for t in trees])
-            subwords = tuple(self.ft_dataset.batch_sentences([t.words for t in trees]))
+            subwords = tuple(self.ft_lexer.batch_sentences([t.words for t in trees]))
             tags = self.pad(
                 [self.tags[j] for j in batch_indices], padding_value=self.LABEL_PADDING
             )

--- a/npdependency/deptree.py
+++ b/npdependency/deptree.py
@@ -332,12 +332,12 @@ class DependencyDataset:
 
         for tree in self.treelist:
             encoded_words = self.lexer.tokenize(tree.words)
-            deptag_idxes = [
+            tag_idxes = [
                 self.tagtoi.get(tag, self.tagtoi[self.UNK_WORD])
                 for tag in tree.pos_tags
             ]
-            deptag_idxes[0] = self.LABEL_PADDING
-            self.tags.append(deptag_idxes)
+            tag_idxes[0] = self.LABEL_PADDING
+            self.tags.append(tag_idxes)
             self.encoded_words.append(encoded_words)
             heads = tree.heads
             heads[0] = self.LABEL_PADDING

--- a/npdependency/graph_parser.py
+++ b/npdependency/graph_parser.py
@@ -508,8 +508,12 @@ class BiAffineParser(nn.Module):
     def from_config(
         cls, config_path: Union[str, pathlib.Path], overrides: Dict[str, Any]
     ) -> "BiAffineParser":
-        print(f"Initializing a parser from {config_path}")
         config_path = pathlib.Path(config_path)
+        if not config_path.exists():
+            config_path = config_path / "config.yaml"
+            if not config_path.exists():
+                raise ValueError(f"No config in {config_path.parent}")
+        print(f"Initializing a parser from {config_path}")
         with open(config_path) as in_stream:
             hp = yaml.load(in_stream, Loader=yaml.SafeLoader)
         hp.update(overrides)

--- a/npdependency/graph_parser.py
+++ b/npdependency/graph_parser.py
@@ -9,6 +9,7 @@ import tempfile
 import warnings
 from typing import (
     Any,
+    BinaryIO,
     Callable,
     Dict,
     IO,
@@ -180,10 +181,10 @@ class BiAffineParser(nn.Module):
             mlp_input, len(self.labels), bias=biased_biaffine
         ).to(self.device)
 
-    def save_params(self, path: Union[str, pathlib.Path, IO]):
+    def save_params(self, path: Union[str, pathlib.Path, BinaryIO]):
         torch.save(self.state_dict(), path)
 
-    def load_params(self, path: Union[str, pathlib.Path, IO]):
+    def load_params(self, path: Union[str, pathlib.Path, BinaryIO]):
         state_dict = torch.load(path, map_location=self.device)
         # Legacy models do not have BERT layer weights, so we inject them here they always use only
         # 4 layers so we don't have to guess the size of the weight vector
@@ -354,6 +355,7 @@ class BiAffineParser(nn.Module):
         model_path: Union[str, pathlib.Path],
         batch_size: Optional[int] = None,
     ):
+        model_path = pathlib.Path(model_path)
         if batch_size is None:
             batch_size = self.default_batch_size
         print(f"Start training on {self.device}")
@@ -520,7 +522,7 @@ class BiAffineParser(nn.Module):
         shutil.copy(config_path, model_config_path)
         fasttext_model_path = model_path / "fasttext_model.bin"
         if fasttext is None:
-            print(f"Generating a FastText model from the treebank")
+            print("Generating a FastText model from the treebank")
             FastTextTorch.train_model_from_sents(
                 [tree.words[1:] for tree in treebank], fasttext_model_path
             )

--- a/npdependency/graph_parser.py
+++ b/npdependency/graph_parser.py
@@ -253,7 +253,7 @@ class BiAffineParser(nn.Module):
 
         # LABEL LOSS
         # We will select the labels for the true heads, so we have to give a true head to
-        # the padding tokens (even if they will be ignore in the crossentropy since the true
+        # the padding tokens (even if they will be ignored in the crossentropy since the true
         # label for that head is set to -100) so we give them the root.
         positive_heads = batch.heads.masked_fill(batch.content_mask.logical_not(), 0)
         # [batch, 1, 1, sent_len]

--- a/npdependency/graph_parser.py
+++ b/npdependency/graph_parser.py
@@ -505,7 +505,7 @@ class BiAffineParser(nn.Module):
             print(str(tree), file=ostream, end="\n\n")
 
     @classmethod
-    def from_config(
+    def load(
         cls, config_path: Union[str, pathlib.Path], overrides: Dict[str, Any]
     ) -> "BiAffineParser":
         config_path = pathlib.Path(config_path)
@@ -615,7 +615,7 @@ def parse(
 ):
     if overrides is None:
         overrides = dict()
-    parser = BiAffineParser.from_config(config_file, overrides)
+    parser = BiAffineParser.load(config_file, overrides)
     testtrees = DependencyDataset.read_conll(in_file)
     # FIXME: the special tokens should be saved somewhere instead of hardcoded
     ft_dataset = FastTextDataSet(parser.ft_lexer, special_tokens=[DepGraph.ROOT_TOKEN])
@@ -777,7 +777,7 @@ def main(argv=None):
             itotag = gen_tags(traintrees)
             savelist(itotag, os.path.join(model_dir, "tagcodes.lst"))
 
-        parser = BiAffineParser.from_config(config_file, overrides)
+        parser = BiAffineParser.load(config_file, overrides)
 
         ft_dataset = FastTextDataSet(
             parser.ft_lexer, special_tokens=[DepGraph.ROOT_TOKEN]

--- a/npdependency/graph_parser.py
+++ b/npdependency/graph_parser.py
@@ -557,6 +557,9 @@ class BiAffineParser(nn.Module):
             if not bert_config_path.exists():
                 lexer.bert.config.save_pretrained(bert_config_path)
                 lexer.bert_tokenizer.save_pretrained(bert_config_path)
+                # Saving local paths in config is of little use and leaks information
+                if os.path.exists(hp["lexer"]):
+                    hp["lexer"] = "."
 
         # char rnn processor
         ordered_charset = CharDataSet(
@@ -594,6 +597,10 @@ class BiAffineParser(nn.Module):
             parser.load_params(str(weights_file))
         else:
             parser.save_params(str(weights_file))
+            # We were actually initializing — rather than loading — the model, let's save the
+            # config with our changes
+            with open(config_path, "w") as out_stream:
+                yaml.dump(hp, out_stream)
 
         if hp.get("freeze_fasttext", False):
             freeze_module(ft_lexer)

--- a/npdependency/graph_parser.py
+++ b/npdependency/graph_parser.py
@@ -514,7 +514,7 @@ class BiAffineParser(nn.Module):
     ) -> "BiAffineParser":
         model_path.mkdir(parents=True, exist_ok=False)
         # TODO: remove this once we have a proper full save method?
-        model_config_path = model_path / "config.yml"
+        model_config_path = model_path / "config.yaml"
         shutil.copy(config_path, model_config_path)
         fasttext_model_path = model_path / "fasttext_model.bin"
         if fasttext is None:
@@ -567,7 +567,7 @@ class BiAffineParser(nn.Module):
         model_path = pathlib.Path(model_path)
         if model_path.is_dir():
             config_dir = model_path
-            model_path = model_path / "config.yml"
+            model_path = model_path / "config.yaml"
             if not model_path.exists():
                 raise ValueError(f"No config in {model_path.parent}")
         else:

--- a/npdependency/graph_parser.py
+++ b/npdependency/graph_parser.py
@@ -532,11 +532,16 @@ class BiAffineParser(nn.Module):
                 unk_word=DependencyDataset.UNK_WORD,
             )
         else:
+            bert_config_path = config_dir / "bert_config"
+            if bert_config_path.exists():
+                bert_model = str(bert_config_path)
+            else:
+                bert_model = hp["lexer"]
             bert_layers = hp.get("bert_layers", [4, 5, 6, 7])
             if bert_layers == "*":
                 bert_layers = None
             lexer = BertBaseLexer(
-                bert_modelfile=hp["lexer"],
+                bert_model=bert_model,
                 bert_layers=bert_layers,
                 bert_subwords_reduction=hp.get("bert_subwords_reduction", "first"),
                 bert_weighted=hp.get("bert_weighted", False),
@@ -546,6 +551,9 @@ class BiAffineParser(nn.Module):
                 words_padding_idx=DependencyDataset.PAD_IDX,
                 word_dropout=hp["word_dropout"],
             )
+            if not bert_config_path.exists():
+                lexer.bert.config.save_pretrained(bert_config_path)
+                lexer.bert_tokenizer.save_pretrained(bert_config_path)
 
         # char rnn processor
         ordered_charset = CharDataSet(

--- a/npdependency/lexers.py
+++ b/npdependency/lexers.py
@@ -210,7 +210,7 @@ class FastTextTorch(nn.Module):
     It follows the same interface as the CharRNN
     """
 
-    def __init__(self, fasttextmodel: fasttext.FastText):
+    def __init__(self, fasttextmodel: fasttext.FastText._FastText):
         super(FastTextTorch, self).__init__()
         self.fasttextmodel = fasttextmodel
         weights = torch.from_numpy(fasttextmodel.get_input_matrix())
@@ -249,7 +249,7 @@ class FastTextTorch(nn.Module):
         return self.embeddings(xinput).mean(dim=1)
 
     @classmethod
-    def loadmodel(cls, modelfile: Union[str, pathlib.Path]) -> "FastTextTorch":
+    def load(cls, modelfile: Union[str, pathlib.Path]) -> "FastTextTorch":
         return cls(fasttext.load_model(str(modelfile)))
 
     @classmethod
@@ -307,7 +307,7 @@ class DefaultLexer(nn.Module):
         self.embedding = nn.Embedding(
             len(itos), embedding_size, padding_idx=words_padding_idx
         )
-        self.embedding_size = embedding_size  # thats the interface property
+        self.embedding_size = embedding_size
         self.itos = itos
         self.stoi = {token: idx for idx, token in enumerate(self.itos)}
         self.unk_word_idx = self.stoi[unk_word]
@@ -332,13 +332,7 @@ class DefaultLexer(nn.Module):
         return self.embedding(word_sequences)
 
     def tokenize(self, tok_sequence: Sequence[str]) -> List[int]:
-        """
-        This maps word tokens to integer indexes.
-        Args:
-           tok_sequence: a sequence of strings
-        Returns:
-           a list of integers
-        """
+        """Map word tokens to integer indices."""
         word_idxes = [self.stoi.get(token, self.unk_word_idx) for token in tok_sequence]
         return word_idxes
 

--- a/npdependency/lexers.py
+++ b/npdependency/lexers.py
@@ -1,5 +1,6 @@
 import os.path
 from collections import Counter
+import pathlib
 from tempfile import gettempdir
 from typing import Iterable, List, NamedTuple, Optional, Sequence, TypeVar, Union
 
@@ -248,12 +249,12 @@ class FastTextTorch(nn.Module):
         return self.embeddings(xinput).mean(dim=1)
 
     @classmethod
-    def loadmodel(cls, modelfile: str) -> "FastTextTorch":
-        return cls(fasttext.load_model(modelfile))
+    def loadmodel(cls, modelfile: Union[str, pathlib.Path]) -> "FastTextTorch":
+        return cls(fasttext.load_model(str(modelfile)))
 
     @classmethod
     def train_model_from_sents(
-        cls, source_sents: Iterable[List[str]], target_file: str
+        cls, source_sents: Iterable[List[str]], target_file: Union[str, pathlib.Path]
     ) -> "FastTextTorch":
         if os.path.exists(target_file):
             raise ValueError(f"{target_file} already exists!")
@@ -270,12 +271,12 @@ class FastTextTorch(nn.Module):
             model = fasttext.train_unsupervised(
                 source_file, model="skipgram", neg=10, minCount=5, epoch=10
             )
-            model.save_model(target_file)
+            model.save_model(str(target_file))
         return cls(model)
 
     @classmethod
     def train_model_from_raw(
-        cls, raw_text_path: str, target_file: str
+        cls, raw_text_path: Union[str, pathlib.Path], target_file: Union[str, pathlib.Path]
     ) -> "FastTextTorch":
         if os.path.exists(target_file):
             raise ValueError(f"{target_file} already exists!")

--- a/npdependency/main.py
+++ b/npdependency/main.py
@@ -20,7 +20,7 @@ def cli():
 @cli.command(help="Parse a raw or tokenized file")
 @click.argument(
     "config_path",
-    type=click_pathlib.Path(resolve_path=True, exists=True, dir_okay=False),
+    type=click_pathlib.Path(resolve_path=True, exists=True),
 )
 @click.argument(
     "input_path",
@@ -78,7 +78,7 @@ def parse(
 @cli.command(help="Start a parsing server")
 @click.argument(
     "config_path",
-    type=click_pathlib.Path(resolve_path=True, exists=True, dir_okay=False),
+    type=click_pathlib.Path(resolve_path=True, exists=True),
 )
 @click.option(
     "--device", default="cpu", help="The device to use for parsing. (cpu, gpu:0, …).", show_default=True

--- a/npdependency/server.py
+++ b/npdependency/server.py
@@ -16,7 +16,7 @@ settings = Settings()
 
 
 models = {
-    model_name: graph_parser.BiAffineParser.from_config(
+    model_name: graph_parser.BiAffineParser.load(
         config_path, overrides={"device": settings.device}
     )
     for model_name, config_path in settings.models.items()

--- a/tox.ini
+++ b/tox.ini
@@ -7,9 +7,9 @@ skip_missing_interpreters = true
 allowlist_externals=cmp
 commands =
     graph_parser --train_file tests/fixtures/truncated-sv_talbanken-ud-dev.conllu --dev_file tests/fixtures/truncated-sv_talbanken-ud-dev.conllu --pred_file tests/fixtures/truncated-sv_talbanken-ud-dev.conllu --out_dir {envtmpdir}/nobert-smoketest-output tests/fixtures/toy_nobert.yaml
-    hopsparser parse {envtmpdir}/nobert-smoketest-output/model/toy_nobert.yaml tests/fixtures/truncated-sv_talbanken-ud-dev.conllu {envtmpdir}/nobert-smoketest-output/truncated-sv_talbanken-ud-dev.conllu.parsed2
+    hopsparser parse {envtmpdir}/nobert-smoketest-output/model tests/fixtures/truncated-sv_talbanken-ud-dev.conllu {envtmpdir}/nobert-smoketest-output/truncated-sv_talbanken-ud-dev.conllu.parsed2
     cmp {envtmpdir}/nobert-smoketest-output/truncated-sv_talbanken-ud-dev.conllu.parsed2 {envtmpdir}/nobert-smoketest-output/truncated-sv_talbanken-ud-dev.conllu.parsed
-    hopsparser parse --raw {envtmpdir}/nobert-smoketest-output/model/toy_nobert.yaml tests/fixtures/raw.txt {envtmpdir}/nobert-smoketest-output/raw.conllu.parsed2
+    hopsparser parse --raw {envtmpdir}/nobert-smoketest-output/model tests/fixtures/raw.txt {envtmpdir}/nobert-smoketest-output/raw.conllu.parsed2
     eval_parse -v tests/fixtures/truncated-sv_talbanken-ud-dev.conllu {envtmpdir}/nobert-smoketest-output/truncated-sv_talbanken-ud-dev.conllu.parsed
     graph_parser --train_file tests/fixtures/truncated-sv_talbanken-ud-dev.conllu --dev_file tests/fixtures/truncated-sv_talbanken-ud-dev.conllu --pred_file tests/fixtures/truncated-sv_talbanken-ud-dev.conllu --out_dir {envtmpdir}/flaubert-smoketest-output tests/fixtures/toy_flaubert.yaml
     eval_parse -v tests/fixtures/truncated-sv_talbanken-ud-dev.conllu {envtmpdir}/flaubert-smoketest-output/truncated-sv_talbanken-ud-dev.conllu.parsed


### PR DESCRIPTION
Makes pretrained models more portable and some other miscellaneous changes. Existing models should still be usable.

## Added

- `BiAffineParser` now has an `initialize` class method that allow creating a model from a config, a treebank and an optional FastText model or raw data for FastText training. This allows creating a model programmatically while previously it was only possible from the CLI.

## Changed

- When using a BERT lexer, we now save the model config and tokenizer in the model directory (the weights were already save) and remove the path/reference in the saved config file so parser models using a local BERT model with a custom config or tokenizer are now a lot more portable. Saved models using a remote BERT model are still loadable but will be removed in the future (when we change the configuration API :-)
- `BiAffineParser.from_config` has been renamed `BiAffineParser.load` to reflect the fact that it actually loads an existing model from a model dir (including vocabulary files, fasttext model…) rather than just a config file. It also now accepts loading by directory path (and look for a `config.yaml` file in it) in addition to config file path. Loading by config file path will be removed in the future.
- The YAML config files in model dirs are now always named `config.yaml` instead of preserving the name of the initial config file, to make the model dirs contents more predictable.
- `lexers.CharDataset` and `lexers.CharRNN` have been merged in `lexers.CharRNNLexer`
- `lexers.FastTextDataset` and `lexers.FastTextTorch` have been merged in `lexers.FastTextLexer`

## Removed

- `lexers.CharRNNLexer` does not inherit the `from_wordlist` method of `lexers.CharDataset`,  for now chars vocabularies have to be created manually (this will change soon once we unify the lexer API)