### PR TITLE
Fix loading current models 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
         strategy:
             max-parallel: 4
             matrix:
-                python-version: [3.7, 3.8, 3.9]
+                python-version: [3.7, 3.8]
         steps:
             - uses: actions/checkout@v1
             - name: Set up Python ${{ matrix.python-version }}

--- a/npdependency/graph_parser.py
+++ b/npdependency/graph_parser.py
@@ -765,6 +765,7 @@ def main(argv=None):
     if args.train_file and args.out_dir:
         model_dir = pathlib.Path(args.out_dir) / "model"
         config_file = pathlib.Path(args.config_file)
+        trained_config_file = model_dir / "config.yaml"
     else:
         model_dir = pathlib.Path(args.config_file).parent
         # We need to give the temp file a name to avoid garbage collection before the method exits
@@ -772,6 +773,7 @@ def main(argv=None):
         _temp_config_file = tempfile.NamedTemporaryFile()
         shutil.copy(args.config_file, _temp_config_file.name)
         config_file = pathlib.Path(_temp_config_file.name)
+        trained_config_file = pathlib.Path(args.config_file)
 
     with open(config_file) as in_stream:
         hp = yaml.load(in_stream, Loader=yaml.SafeLoader)
@@ -789,6 +791,9 @@ def main(argv=None):
             parser = BiAffineParser.load(model_dir, overrides)
         else:
             if args.overwrite:
+                if not args.out_dir:
+                    print("ERROR: overwriting is only supported with --out_dir", file=sys.stderr)
+                    return 1
                 print(
                     f"Erasing existing trained model in {model_dir} since --overwrite was asked",
                     file=sys.stderr,
@@ -864,8 +869,8 @@ def main(argv=None):
                 os.path.dirname(args.pred_file),
                 f"{os.path.basename(args.pred_file)}.parsed",
             )
-        parse(model_dir, args.pred_file, parsed_testset_path, overrides=overrides)
-        print("parsing done.", file=sys.stderr)
+        parse(trained_config_file, args.pred_file, parsed_testset_path, overrides=overrides)
+        print("Parsing done.", file=sys.stderr)
 
 
 if __name__ == "__main__":

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,7 +14,7 @@ keywords =
 [options]
 packages = find:
 include_package_data=True
-python_requires = >= 3.7, < 3.9
+python_requires = >= 3.7
 install_requires =
     click
     click_pathlib

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,15 +14,14 @@ keywords =
 [options]
 packages = find:
 include_package_data=True
-python_requires = >= 3.7
+python_requires = >= 3.7, < 3.9
 install_requires =
     click
     click_pathlib
     fastapi
     fasttext
     pyyaml
-    torch >= 1.6, < 2.0.0 ; python_version<="3.8"
-    torch >= 1.8, < 2.0.0 ; python_version>="3.9"
+    torch == 1.7.1
     transformers >= 4.0.0, < 5.0.0
     typing_extensions
     uvicorn


### PR DESCRIPTION
This is a short-term fix for #35 and an unrelated issue that had removed the ability to use `graph_parser` in inference only mode with old-style models (we reintroduce it here but deprecate it, people should use `hopsparser parse` instead).