### PR TITLE
Update to Pytorch 1.8

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
         strategy:
             max-parallel: 4
             matrix:
-                python-version: [3.7, 3.8]
+                python-version: [3.7, 3.8, 3.9]
         steps:
             - uses: actions/checkout@v1
             - name: Set up Python ${{ matrix.python-version }}

--- a/models.md
+++ b/models.md
@@ -16,11 +16,11 @@ running them on CPUs is still possible, albeit slow.
 | UD_French-FTB-2.7-flaubert  | 98.51      | 88.26     | 98.58       | 88.55      | [link][UD_French-FTB-2.7-flaubert]  |
 | UD_French-FTB-2.7-nobert    | 97.81      | 84.69     | 97.85       | 83.93      | [link][UD_French-FTB-2.7-nobert]    |
 
-[UD_French-FTB-2.7-camembert]: https://sharedocs.huma-num.fr/wl/?id=d3IzkD0j011kN8yDaPkhA7P21XSGR9zE
+[UD_French-FTB-2.7-camembert]: https://sharedocs.huma-num.fr/wl/?id=qu7IhWYrISIcQDrHUzcf774JkCXfyBI1
 
-[UD_French-FTB-2.7-flaubert]: https://sharedocs.huma-num.fr/wl/?id=LPI6M69bWEIBPhlEUdVOf8MDjotH62km
+[UD_French-FTB-2.7-flaubert]: https://sharedocs.huma-num.fr/wl/?id=6b2tnCQf9HFTEZsdnTmnEvAbloPubjNV
 
-[UD_French-FTB-2.7-nobert]: https://sharedocs.huma-num.fr/wl/?id=NR27gyIoicaxxWlcj4lnvu0QpDGP84xp
+[UD_French-FTB-2.7-nobert]: https://sharedocs.huma-num.fr/wl/?id=lCtafL0B6z53Rxc6MXbJM2d4kpZq0p0e
 
 ### FTB-SPMRL
 
@@ -30,11 +30,11 @@ running them on CPUs is still possible, albeit slow.
 | ftb_spmrl-flaubert  | 98.87      | 89.47     | 98.78       | 89.64      | [link][ftb_spmrl-flaubert]  |
 | ftb_spmrl-nobert    | 98.2       | 85.2      | 98.13       | 84.49      | [link][ftb_spmrl-nobert]    |
 
-[ftb_spmrl-camembert]: https://sharedocs.huma-num.fr/wl/?id=YmSZmlZovSRwvOCmVxlrIBTc6lDhrNeo
+[ftb_spmrl-camembert]: https://sharedocs.huma-num.fr/wl/?id=CkLcU78r5JZ6hDZ5OBuyUJM9ffh6ksgn
 
-[ftb_spmrl-flaubert]: https://sharedocs.huma-num.fr/wl/?id=fyvPzaP2Xo8PU31gsAN0a0qLnSmjrgq3
+[ftb_spmrl-flaubert]: https://sharedocs.huma-num.fr/wl/?id=Hqv26oIWT4cSqSET5OTo82rxxfCTrTln
 
-[ftb_spmrl-nobert]: https://sharedocs.huma-num.fr/wl/?id=EM0Jm8jzPUONRyE9H4EREQ30689OxIov
+[ftb_spmrl-nobert]: https://sharedocs.huma-num.fr/wl/?id=8620wtCFnVcvmuP6i2njblOd4dXdGtmV
 
 ### GSD-UD
 
@@ -44,11 +44,11 @@ running them on CPUs is still possible, albeit slow.
 | UD_French-GSD-2.7-flaubert  | 98.57      | 95.49     | 98.53       | 94.24      | [link][UD_French-GSD-2.7-flaubert]  |
 | UD_French-GSD-2.7-nobert    | 97.77      | 91.67     | 97.5        | 88.93      | [link][UD_French-GSD-2.7-nobert]    |
 
-[UD_French-GSD-2.7-camembert]: https://sharedocs.huma-num.fr/wl/?id=1EjeZn3JCDDO6ulIgUffY5Rq3qvP7j1I
+[UD_French-GSD-2.7-camembert]: https://sharedocs.huma-num.fr/wl/?id=3Ax0VXpnsmUuzqTHPnunBnUVW6AgS1rC
 
-[UD_French-GSD-2.7-flaubert]: https://sharedocs.huma-num.fr/wl/?id=y0e4VHIwkLe3hggccKbMMf5Sa2TvpXxd
+[UD_French-GSD-2.7-flaubert]: https://sharedocs.huma-num.fr/wl/?id=5u7UgVA9cN3GHI6VmyUTvmQI6iDyyU8S
 
-[UD_French-GSD-2.7-nobert]: https://sharedocs.huma-num.fr/wl/?id=nLN86K0ZwH7j3vD8K3zlqZwgKfv8fo4i
+[UD_French-GSD-2.7-nobert]: https://sharedocs.huma-num.fr/wl/?id=xTQ6Bt1EiKakjLsn9xUUe7UGDcXjeu19
 
 ### Sequoia-UD
 
@@ -58,11 +58,11 @@ running them on CPUs is still possible, albeit slow.
 | UD_French-Sequoia-2.7-flaubert  | 99.18      | 94.13     | 99.33       | 94.71      | [link][UD_French-Sequoia-2.7-flaubert]  |
 | UD_French-Sequoia-2.7-nobert    | 96.89      | 85.26     | 97.32       | 85.29      | [link][UD_French-Sequoia-2.7-nobert]    |
 
-[UD_French-Sequoia-2.7-camembert]: https://sharedocs.huma-num.fr/wl/?id=xrGkUv2Mq4ddW4KVdKBehsq0yn3UzpWU
+[UD_French-Sequoia-2.7-camembert]: https://sharedocs.huma-num.fr/wl/?id=GW5ue77TNS99lQAZJ8fb5ujtj1rEmBfj
 
-[UD_French-Sequoia-2.7-flaubert]: https://sharedocs.huma-num.fr/wl/?id=L2WEbxUjQhLGxJ0ABglPuK02JWUhejkV
+[UD_French-Sequoia-2.7-flaubert]: https://sharedocs.huma-num.fr/wl/?id=z6NYjiGPVVzOEfTJQ5pQFRYfvpbzVcQq
 
-[UD_French-Sequoia-2.7-nobert]: https://sharedocs.huma-num.fr/wl/?id=Q0hVQbtn7jK3BGZqwQbTA4HNpOrWkl5g
+[UD_French-Sequoia-2.7-nobert]: https://sharedocs.huma-num.fr/wl/?id=TLhIy5ShxzEOPBUd8YaftFSI99E1qxQk
 
 ### French-Spoken-UD
 
@@ -72,11 +72,11 @@ running them on CPUs is still possible, albeit slow.
 | UD_French-Spoken-2.7-flaubert  | 97.05      | 79.84     | 96.67       | 78.72      | [link][UD_French-Spoken-2.7-flaubert]  |
 | UD_French-Spoken-2.7-nobert    | 93.72      | 72.71     | 92.75       | 71.02      | [link][UD_French-Spoken-2.7-nobert]    |
 
-[UD_French-Spoken-2.7-camembert]: https://sharedocs.huma-num.fr/wl/?id=9XuMjPlMPPzxekIid1wJTq53XUPhmkei
+[UD_French-Spoken-2.7-camembert]: https://sharedocs.huma-num.fr/wl/?id=MiCoXaMelAQEzxZGzzKTrSGmCIGfNwFd
 
-[UD_French-Spoken-2.7-flaubert]: https://sharedocs.huma-num.fr/wl/?id=5DfSBR6kAHrJjfVQhUbad3Y6oAvifd9n
+[UD_French-Spoken-2.7-flaubert]: https://sharedocs.huma-num.fr/wl/?id=x6BswC571NYGO2760Imz4ShtgURajIua
 
-[UD_French-Spoken-2.7-nobert]: https://sharedocs.huma-num.fr/wl/?id=5oZ0Oio6R1yO4cqsi9Dn9RsGLkVONt3m
+[UD_French-Spoken-2.7-nobert]: https://sharedocs.huma-num.fr/wl/?id=2g7oP1qGb1gxH6M2fjEnRi0N6UNVBh6H
 
 ## Old French
 

--- a/models.md
+++ b/models.md
@@ -12,9 +12,9 @@ running them on CPUs is still possible, albeit slow.
 
 | Model name                  | UPOS (dev) | LAS (dev) | UPOS (test) | LAS (test) | Download                            |
 | --------------------------- | ---------- | --------- | ----------- | ---------- | ----------------------------------- |
-| UD_French-FTB-2.7-camembert | 98.42      | 88.23     | 98.55       | 88.38      | [link][UD_French-FTB-2.7-camembert] |
-| UD_French-FTB-2.7-flaubert  | 98.51      | 88.26     | 98.58       | 88.55      | [link][UD_French-FTB-2.7-flaubert]  |
-| UD_French-FTB-2.7-nobert    | 97.81      | 84.69     | 97.85       | 83.93      | [link][UD_French-FTB-2.7-nobert]    |
+| UD_French-FTB-2.7-camembert | 98.46      |88.25      |98.56      |88.44      | [link][UD_French-FTB-2.7-camembert] |
+| UD_French-FTB-2.7-flaubert  | 98.51      |88.27      |98.61      |88.46      | [link][UD_French-FTB-2.7-flaubert]  |
+| UD_French-FTB-2.7-nobert    | 97.86      |84.28      |97.89      |83.91      | [link][UD_French-FTB-2.7-nobert]    |
 
 [UD_French-FTB-2.7-camembert]: https://sharedocs.huma-num.fr/wl/?id=qu7IhWYrISIcQDrHUzcf774JkCXfyBI1
 
@@ -26,9 +26,9 @@ running them on CPUs is still possible, albeit slow.
 
 | Model name          | UPOS (dev) | LAS (dev) | UPOS (test) | LAS (test) | Download                    |
 | ------------------- | ---------- | --------- | ----------- | ---------- | --------------------------- |
-| ftb_spmrl-camembert | 98.83      | 89.02     | 98.69       | 89.31      | [link][ftb_spmrl-camembert] |
-| ftb_spmrl-flaubert  | 98.87      | 89.47     | 98.78       | 89.64      | [link][ftb_spmrl-flaubert]  |
-| ftb_spmrl-nobert    | 98.2       | 85.2      | 98.13       | 84.49      | [link][ftb_spmrl-nobert]    |
+| ftb_spmrl-camembert | 98.88      |89.05      |98.74      |89.35      | [link][ftb_spmrl-camembert] |
+| ftb_spmrl-flaubert  | 98.84      |89.22      |98.71      |89.51      | [link][ftb_spmrl-flaubert]  |
+| ftb_spmrl-nobert    | 98.25      |85.37      |98.13      |84.57      | [link][ftb_spmrl-nobert]    |
 
 [ftb_spmrl-camembert]: https://sharedocs.huma-num.fr/wl/?id=CkLcU78r5JZ6hDZ5OBuyUJM9ffh6ksgn
 
@@ -40,9 +40,9 @@ running them on CPUs is still possible, albeit slow.
 
 | Model name                  | UPOS (dev) | LAS (dev) | UPOS (test) | LAS (test) | Download                            |
 | --------------------------- | ---------- | --------- | ----------- | ---------- | ----------------------------------- |
-| UD_French-GSD-2.7-camembert | 98.57      | 95.55     | 98.48       | 94.04      | [link][UD_French-GSD-2.7-camembert] |
-| UD_French-GSD-2.7-flaubert  | 98.57      | 95.49     | 98.53       | 94.24      | [link][UD_French-GSD-2.7-flaubert]  |
-| UD_French-GSD-2.7-nobert    | 97.77      | 91.67     | 97.5        | 88.93      | [link][UD_French-GSD-2.7-nobert]    |
+| UD_French-GSD-2.7-camembert | 98.52      |95.53      |98.22      |94.06      | [link][UD_French-GSD-2.7-camembert] |
+| UD_French-GSD-2.7-flaubert  | 98.51      |88.27      |98.61      |88.46      | [link][UD_French-GSD-2.7-flaubert]  |
+| UD_French-GSD-2.7-nobert    | 97.79      |91.75      |97.28      |88.95      | [link][UD_French-GSD-2.7-nobert]    |
 
 [UD_French-GSD-2.7-camembert]: https://sharedocs.huma-num.fr/wl/?id=3Ax0VXpnsmUuzqTHPnunBnUVW6AgS1rC
 
@@ -54,9 +54,9 @@ running them on CPUs is still possible, albeit slow.
 
 | Model name                      | UPOS (dev) | LAS (dev) | UPOS (test) | LAS (test) | Download                                |
 | ------------------------------- | ---------- | --------- | ----------- | ---------- | --------------------------------------- |
-| UD_French-Sequoia-2.7-camembert | 99.01      | 93.6      | 99.23       | 93.85      | [link][UD_French-Sequoia-2.7-camembert] |
-| UD_French-Sequoia-2.7-flaubert  | 99.18      | 94.13     | 99.33       | 94.71      | [link][UD_French-Sequoia-2.7-flaubert]  |
-| UD_French-Sequoia-2.7-nobert    | 96.89      | 85.26     | 97.32       | 85.29      | [link][UD_French-Sequoia-2.7-nobert]    |
+| UD_French-Sequoia-2.7-camembert | 99.02      |93.26      |99.07      |93.36      | [link][UD_French-Sequoia-2.7-camembert] |
+| UD_French-Sequoia-2.7-flaubert  | 99.16      |94.15      |99.33      |94.31      | [link][UD_French-Sequoia-2.7-flaubert]  |
+| UD_French-Sequoia-2.7-nobert    | 96.97      |85.41      |97.26      |85.63      | [link][UD_French-Sequoia-2.7-nobert]    |
 
 [UD_French-Sequoia-2.7-camembert]: https://sharedocs.huma-num.fr/wl/?id=GW5ue77TNS99lQAZJ8fb5ujtj1rEmBfj
 
@@ -68,9 +68,9 @@ running them on CPUs is still possible, albeit slow.
 
 | Model name                     | UPOS (dev) | LAS (dev) | UPOS (test) | LAS (test) | Download                               |
 | ------------------------------ | ---------- | --------- | ----------- | ---------- | -------------------------------------- |
-| UD_French-Spoken-2.7-camembert | 96.49      | 80.82     | 96.35       | 78.63      | [link][UD_French-Spoken-2.7-camembert] |
-| UD_French-Spoken-2.7-flaubert  | 97.05      | 79.84     | 96.67       | 78.72      | [link][UD_French-Spoken-2.7-flaubert]  |
-| UD_French-Spoken-2.7-nobert    | 93.72      | 72.71     | 92.75       | 71.02      | [link][UD_French-Spoken-2.7-nobert]    |
+| UD_French-Spoken-2.7-camembert | 96.97      |80.38      |96.83      |79.72      | [link][UD_French-Spoken-2.7-camembert] |
+| UD_French-Spoken-2.7-flaubert  | 97.06      |80.68      |96.69      |79.15      | [link][UD_French-Spoken-2.7-flaubert]  |
+| UD_French-Spoken-2.7-nobert    | 93.94      |72.61      |93.42      |71.66      | [link][UD_French-Spoken-2.7-nobert]    |
 
 [UD_French-Spoken-2.7-camembert]: https://sharedocs.huma-num.fr/wl/?id=MiCoXaMelAQEzxZGzzKTrSGmCIGfNwFd
 

--- a/models.md
+++ b/models.md
@@ -86,6 +86,6 @@ running them on CPUs is still possible, albeit slow.
 
 | Model name                       | UPOS (dev) | LAS (dev) | UPOS (test) | LAS (test) | Download                                 |
 | -------------------------------- | ---------- | --------- | ----------- | ---------- | ---------------------------------------- |
-| UD_Old_French-SRCMF-flaubert+fro | 97.21      | 90.14     | 97.40       | 90.56      | [link][UD_Old_French-SRCMF-flaubert+fro] |
+| UD_Old_French-SRCMF-flaubert+fro | 97.11      | 90.43     | 97.34       | 90.78      | [link][UD_Old_French-SRCMF-flaubert+fro] |
 
-[UD_Old_French-SRCMF-flaubert+fro]: https://sharedocs.huma-num.fr/wl/?id=U3LQ1dGJmzJfIchpTMGyzU7TDmALQy9E
+[UD_Old_French-SRCMF-flaubert+fro]: https://sharedocs.huma-num.fr/wl/?id=cCWgzz3vQn5PacxKUDjjDpILvJeX0B14

--- a/npdependency/graph_parser.py
+++ b/npdependency/graph_parser.py
@@ -200,6 +200,16 @@ class BiAffineParser(nn.Module):
         xft: Iterable[torch.Tensor],
         sent_lengths: torch.Tensor,
     ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        """Predict POS, heads and deprel scores.
+
+        ## Outputs
+
+        `tag_scores, arc_scores, lab_scores` with shapes
+
+        - `tag_score`: $`batch_size×max_sent_length×num_pos_tags`$
+        - `arc_scores`: $`batch_size×max_sent_length×max_sent_length`$
+        - `label_scores`: $`batch_size×num_deprels×max_sent_length×max_sent_length`$
+        """
         # Computes char embeddings
         char_embed = torch.stack([self.char_rnn(column) for column in xchars], dim=1)
         # Computes fasttext embeddings

--- a/npdependency/lexers.py
+++ b/npdependency/lexers.py
@@ -179,10 +179,10 @@ class FastTextLexer(nn.Module):
         ).to(torch.float)
         weights.requires_grad = True
         self.embeddings = nn.Embedding.from_pretrained(
-            weights, padding_idx=self.vocab_size + 1
+            weights, padding_idx=self.vocab_size
         )
         self.special_tokens: Set = set([] if special_tokens is None else special_tokens)
-        self.special_tokens_idx: Final[int] = self.vocab_size + 2
+        self.special_tokens_idx: Final[int] = self.vocab_size + 1
         self.pad_idx: Final[int] = self.embeddings.padding_idx
 
     def subwords_idxes(self, token: str) -> torch.Tensor:

--- a/npdependency/lexers.py
+++ b/npdependency/lexers.py
@@ -182,7 +182,7 @@ class FastTextLexer(nn.Module):
             weights, padding_idx=self.vocab_size + 1
         )
         self.special_tokens: Set = set([] if special_tokens is None else special_tokens)
-        self.special_tokens_idx: Final[int] = self.vocab_size
+        self.special_tokens_idx: Final[int] = self.vocab_size + 2
         self.pad_idx: Final[int] = self.embeddings.padding_idx
 
     def subwords_idxes(self, token: str) -> torch.Tensor:

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,7 +21,7 @@ install_requires =
     fastapi
     fasttext
     pyyaml
-    torch == 1.7.1
+    torch ~= 1.8.0
     transformers >= 4.0.0, < 5.0.0
     typing_extensions
     uvicorn

--- a/tox.ini
+++ b/tox.ini
@@ -13,6 +13,3 @@ commands =
     eval_parse -v tests/fixtures/truncated-sv_talbanken-ud-dev.conllu {envtmpdir}/nobert-smoketest-output/truncated-sv_talbanken-ud-dev.conllu.parsed
     graph_parser --train_file tests/fixtures/truncated-sv_talbanken-ud-dev.conllu --dev_file tests/fixtures/truncated-sv_talbanken-ud-dev.conllu --pred_file tests/fixtures/truncated-sv_talbanken-ud-dev.conllu --out_dir {envtmpdir}/flaubert-smoketest-output tests/fixtures/toy_flaubert.yaml
     eval_parse -v tests/fixtures/truncated-sv_talbanken-ud-dev.conllu {envtmpdir}/flaubert-smoketest-output/truncated-sv_talbanken-ud-dev.conllu.parsed
-
-[py39]
-ignore_outcome = true


### PR DESCRIPTION
Models trained in Pytorch 1.8 and 1.7 are incompatible, which caused #33. This updates and lock Pytorch to 1.8.* and comes with a retraining of all our public pretrained models.