### PR TITLE
Add multi-random seed model training

### DIFF
--- a/npdependency/main.py
+++ b/npdependency/main.py
@@ -21,6 +21,14 @@ except ImportError:
     from typing_extensions import Literal  # type: ignore[misc]
 
 
+device_opt = click.option(
+    "--device",
+    default="cpu",
+    help="The device to use for the parsing model. (cpu, gpu:0, …).",
+    show_default=True,
+)
+
+
 @contextlib.contextmanager
 def dir_manager(
     path: Optional[Union[pathlib.Path, str]] = None
@@ -55,12 +63,7 @@ def cli():
     type=click.Path(resolve_path=True, dir_okay=False, writable=True, allow_dash=True),
     default="-",
 )
-@click.option(
-    "--device",
-    default="cpu",
-    help="The device to use for parsing. (cpu, gpu:0, …).",
-    show_default=True,
-)
+@device_opt
 @click.option(
     "--raw",
     is_flag=True,
@@ -111,12 +114,7 @@ def parse(
     "treebank_path",
     type=click.Path(resolve_path=True, exists=True, dir_okay=False, allow_dash=True),
 )
-@click.option(
-    "--device",
-    default="cpu",
-    help="The device to use for parsing. (cpu, gpu:0, …).",
-    show_default=True,
-)
+@device_opt
 @click.option(
     "--intermediary-dir",
     type=click_pathlib.Path(resolve_path=True, file_okay=False),

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -22,6 +22,11 @@ For each `{config_name}.yaml}` file in `{configs_dir}` and each `{treebank_name}
 train and test set. It will also create a summary of the performances of the various runs in
 `{out_dir}/summary.tsv`.
 
+You can also specify a number of rand seeds with `--rand-seeds seed1,seed2,…`, in which case the
+summary will report descriptive statistics (mean, standard deviation…) for every configuration,
+treebank and additional args combination and ``{out_dir}/best` will contain the results of the best
+runs.
+
 The `--device` flag is used to specify the devices available to train on as comma-separated list.
 The script runs in a rudimentary task queue which distributes the train runs among these devices: every
 run waits until a device is available, then grab it, trains on it and releases it once it is done.
@@ -30,3 +35,13 @@ To make several runs happen concurrently on the same device, just specify it sev
 `--devices "cuda:1,cuda:1"` will maintain two training process on the GPU with index 1. `"cpu"` is
 of course an acceptable device that you can also specify several times and mix with GPU devices, so
 this doesn't require access to GPUs.
+
+For reference, we train our models using
+
+```console
+python scripts/train_models.py {repo_root}/examples/ {resource_dir}/treebanks --devices "cuda:0,cuda:1,cuda:0,cuda:1" --rand_seeds "0,1,2,3,4,5,6,7,8" --out-dir {output_dir}/newmodels --args "fasttext={resource_dir}/fasttext_model.bin"
+```
+
+For our contemporary French models, the whole procedure takes around 36h/seed on our machine.
+
+Note that when running with the same output dir, the existing runs will be preserved (and not re-runned) and aggregated in the summaries, so it's easy to add more runs after the fact.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -3,7 +3,6 @@ Utility scripts
 
 This contains utility scripts that are not part of the parser but make its usage easier.
 
-
 ## `train_models.py`: training a treebank×configs matrix
 
 `train_models.py` is an utility to train and evaluate models using several configs on several
@@ -11,7 +10,7 @@ treebanks. We use it internally to train the models we provide and it is not muc
 we need it to be for that purpose (but PR to improve that are welcome). It also has very little
 error management so if any train run fails it will just hang until you SIGINT or SIGKILL it.
 
-After installing npdependency, it can be run with
+After installing `npdependency[traintools]`, it can be run with
 
 ```console
 python scripts/train_models.py {configs_dir} {treebanks_dir} --args "fasttext={fasttext_model}" --devices "{device1},{device2},{…}" --out-dir {out_dir}

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -24,7 +24,7 @@ train and test set. It will also create a summary of the performances of the var
 
 You can also specify a number of rand seeds with `--rand-seeds seed1,seed2,…`, in which case the
 summary will report descriptive statistics (mean, standard deviation…) for every configuration,
-treebank and additional args combination and ``{out_dir}/best` will contain the results of the best
+treebank and additional args combination and `{out_dir}/best` will contain the results of the best
 runs.
 
 The `--device` flag is used to specify the devices available to train on as comma-separated list.

--- a/scripts/train_models.py
+++ b/scripts/train_models.py
@@ -1,13 +1,16 @@
 import itertools
+import json
 import multiprocessing
 import os.path
 import pathlib
+import shutil
 import subprocess
 import sys
 from typing import Any, Dict, Iterable, List, NamedTuple, Optional, Tuple, Union
 
 import click
 import click_pathlib
+import pandas as pd
 
 from npdependency import conll2018_eval as evaluator
 
@@ -153,7 +156,7 @@ def parse_args_callback(
     callback=(
         lambda _ctx, _opt, val: None
         if val is None
-        else [int(v) for v in val.split(",")]
+        else [int(v) for v in val.split(",") if v]
     ),
     help=(
         "A comma-separated list of random seeds to try and run stats on."
@@ -185,6 +188,7 @@ def main(
             for args_values in itertools.product(*all_args_values)
         ]
     else:
+        args_names = []
         additional_args_combinations = [{}]
     runs: List[Tuple[str, Dict[str, Any]]] = []
     for t in treebanks:
@@ -224,15 +228,55 @@ def main(
 
     res = run_multi(runs, devices)
 
-    summary_file = out_dir / "summary.tsv"
-    if not summary_file.exists():
-        summary_file.write_text("run\tdev UPOS\tdev LAS\ttest UPOS\ttest LAS\n")
-    with open(summary_file, "a") as out_stream:
-        for name, scores in res:
-            out_stream.write(
-                f"{name}\t{100*scores.dev_upos:.2f}\t{100*scores.dev_las:.2f}\t{100*scores.test_upos:.2f}\t{100*scores.test_las:.2f}\n"
-            )
-    # TODO: stats aggregated across random seeds computed here
+    runs_dict = dict(runs)
+    report_file = summary_file = out_dir / "full_report.json"
+    if report_file.exists():
+        with open(report_file) as in_stream:
+            report_dict = json.load(in_stream)
+    else:
+        report_dict = dict()
+    for name, scores in res:
+        run = runs_dict[name]
+        report_dict[name] = {
+            "additional_args": run["additional_args"],
+            "config": run["config_path"],
+            "out_dir": run["out_dir"],
+            "results": scores._asdict(),
+            "treebank": run["train_file"].parent.name,
+        }
+    with open(report_file, "w") as out_stream:
+        json.dump(report_dict, out_stream)
+
+    if rand_seeds is None:
+        summary_file = out_dir / "summary.tsv"
+        with open(summary_file, "w") as out_stream:
+            summary_file.write_text("run\tdev UPOS\tdev LAS\ttest UPOS\ttest LAS\n")
+            for name, report in report_dict.items():
+                out_stream.write(name)
+                for s in ("dev_upos", "dev_las", "test_upos", "test_las"):
+                    out_stream.write(f"\t{100*report['results'][s]:.2f}")
+                out_stream.write("\n")
+    else:
+        df_dict = {
+            run_name: {
+                **{
+                    k: v
+                    for k, v in run_report
+                    if v not in ("additional_args", "results")
+                },
+                **run_report["additional_args"],
+                **run_report["results"],
+            }
+            for run_name, run_report in report_dict.items()
+        }
+        df = pd.DataFrame(df_dict)
+        grouped = df.groupby(["config", "treebank", *args_names], as_index=False)
+        grouped[["dev_upos", "dev_las", "test_upos", "test_las"]].describe().to_csv(
+            summary_file
+        )
+        best_dir = out_dir / "best"
+        for run_name, report in df.loc[grouped["dev_las"].idxmax()].iterrows():
+            shutil.copy(report.out_dir, best_dir / run_name)
 
 
 if __name__ == "__main__":

--- a/scripts/train_models.py
+++ b/scripts/train_models.py
@@ -117,8 +117,6 @@ def parse_args_callback(
     return res
 
 
-# TODO: add multitrials mode, options to report stats and random seed tuning (keeping the best out
-# of n models…)
 @click.command()
 @click.argument(
     "configs_dir",

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,6 +26,9 @@ install_requires =
     typing_extensions
     uvicorn
 
+[options.extras_require]
+traintools = pandas
+
 [options.entry_points]
 console_scripts =
     hopsparser = npdependency.main:cli


### PR DESCRIPTION
The `train_models` script now aggregates results over the given random seeds, providing statistics on the multiple runs and selects the best seed for every training combination. Details in [the scripts Readme](scripts/README.md).

The data manipulation and stats are done in pandas, but to avoid having it as an mandatory requirement, the dependency declared as an [extra](https://setuptools.readthedocs.io/en/latest/userguide/dependency_management.html#optional-dependencies) that can be installed with `pip install git+https://github.com/bencrabbe/npdependency[traintools]`.