### PR TITLE
Add basic pip and transformers cache to ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     lint:
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v1
+            - uses: actions/checkout@v2
             - name: Set up Python 3.9
               uses: actions/setup-python@v2
               with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,14 +37,35 @@ jobs:
             matrix:
                 python-version: [3.7, 3.8, 3.9]
         steps:
-            - uses: actions/checkout@v1
+            - uses: actions/checkout@v2
             - name: Set up Python ${{ matrix.python-version }}
               uses: actions/setup-python@v2
               with:
                   python-version: ${{ matrix.python-version }}
+            - name: Get pip cache
+              id: pip-cache
+              run: |
+                python -c "from pip._internal.locations import USER_CACHE_DIR; print('::set-output name=dir::' + USER_CACHE_DIR)"
+            - uses: actions/cache@v2
+              with:
+                path: ${{ steps.pip-cache.outputs.dir }}
+                key: ${{ runner.os }}-pip-${{ hashFiles('**/setup.cfg') }}
+                restore-keys: |
+                  ${{ runner.os }}-pip-
             - name: Install dependencies
               run: |
                   python -m pip install --upgrade pip wheel setuptools
+            - name: Get transformers and cache
+              id: transfo-install
+              run: |
+                python -m pip install --upgrade transformers
+                python -c "from transformers.file_utils import TRANSFORMERS_CACHE; print('::set-output name=dir::' + TRANSFORMERS_CACHE)"
+            - uses: actions/cache@v2
+              with:
+                path: ${{ steps.transfo-install.outputs.dir }}
+                key: ${{ runner.os }}-transformers-${{ hashFiles('**/setup.cfg') }}
+                restore-keys: |
+                  ${{ runner.os }}-transformers-
             - name: Test with tox
               run: |
                   pip install tox


### PR DESCRIPTION
Cache python packages and transformers models on github actions to make CI faster and lighter.