### PR TITLE
Add a train command

### DIFF
--- a/npdependency/graph_parser.py
+++ b/npdependency/graph_parser.py
@@ -719,7 +719,8 @@ class BiAffineParser(nn.Module):
                 raise ValueError(f"No config in {model_path}")
         else:
             warnings.warn(
-                "Loading a model from a YAML file is deprecated and will be removed in a future version."
+                "Loading a model from a YAML file is deprecated and will be removed in a future version.",
+                category=FutureWarning,
             )
             config_path = model_path
             model_path = model_path.parent
@@ -853,7 +854,8 @@ def train(
         hp = yaml.load(in_stream, Loader=yaml.SafeLoader)
     if "device" in hp:
         warnings.warn(
-            "Setting a device directly in a configuration file is deprecated and will be silently ignored in a future version."
+            "Setting a device directly in a configuration file is DEPRECATED and will be silently ignored in a future version.",
+            category=FutureWarning,
         )
 
     traintrees = list(DepGraph.read_conll(train_file, max_tree_length=max_tree_length))
@@ -1005,7 +1007,10 @@ def main(argv=None):
         type=int,
         help="Force the random seed fo Python and Pytorch (see <https://pytorch.org/docs/stable/notes/randomness.html> for notes on reproducibility)",
     )
-
+    warnings.warn(
+        "The `graph_parser` interface is DEPRECATED and will be removed in a future release, use `hopsparser train` instead",
+        category=FutureWarning,
+    )
     args = parser.parse_args(argv)
 
     if args.overwrite and not args.out_dir:
@@ -1028,7 +1033,7 @@ def main(argv=None):
     else:
         model_dir = pathlib.Path(args.config_file).parent
         # We need to give the temp file a name to avoid garbage collection before the method exits
-        # this is not very clean but this code path will be deprecated soon anyway.
+        # this is not very clean but this code path will be removed soon anyway.
         _temp_config_file = tempfile.NamedTemporaryFile()
         shutil.copy(args.config_file, _temp_config_file.name)
         config_file = pathlib.Path(_temp_config_file.name)

--- a/npdependency/graph_parser.py
+++ b/npdependency/graph_parser.py
@@ -836,9 +836,9 @@ def loadlist(filename):
 
 def train(
     config_file: pathlib.Path,
-    model_dir: pathlib.Path,
+    model_path: pathlib.Path,
     train_file: pathlib.Path,
-    fasttext_model: Optional[pathlib.Path],
+    fasttext: Optional[pathlib.Path],
     max_tree_length: Optional[int] = None,
     overrides: Optional[Dict[str, str]] = None,
     overwrite: bool = False,
@@ -857,22 +857,22 @@ def train(
         )
 
     traintrees = list(DepGraph.read_conll(train_file, max_tree_length=max_tree_length))
-    if model_dir.exists() and not overwrite:
-        print(f"Continuing training from {model_dir}", file=sys.stderr)
-        parser = BiAffineParser.load(model_dir, overrides)
+    if model_path.exists() and not overwrite:
+        print(f"Continuing training from {model_path}", file=sys.stderr)
+        parser = BiAffineParser.load(model_path, overrides)
     else:
         if overwrite:
             print(
-                f"Erasing existing trained model in {model_dir} since overwrite was asked",
+                f"Erasing existing trained model in {model_path} since overwrite was asked",
                 file=sys.stderr,
             )
-            shutil.rmtree(model_dir)
+            shutil.rmtree(model_path)
         parser = BiAffineParser.initialize(
             config_path=config_file,
-            model_path=model_dir,
+            model_path=model_path,
             overrides=overrides,
             treebank=traintrees,
-            fasttext=fasttext_model,
+            fasttext=fasttext,
         )
 
     trainset = DependencyDataset(
@@ -901,7 +901,7 @@ def train(
         epochs=hp["epochs"],
         lr=hp["lr"],
         lr_schedule=hp.get("lr_schedule", {"shape": "exponential", "warmup_steps": 0}),
-        model_path=model_dir,
+        model_path=model_path,
         train_set=trainset,
     )
 
@@ -1040,11 +1040,11 @@ def main(argv=None):
             config_file=pathlib.Path(config_file),
             dev_file=pathlib.Path(args.dev_file),
             train_file=pathlib.Path(args.train_file),
-            fasttext_model=(
+            fasttext=(
                 pathlib.Path(args.fasttext) if args.fasttext is not None else None
             ),
             max_tree_length=150,
-            model_dir=model_dir,
+            model_path=model_dir,
             overrides=overrides,
             overwrite=args.overwrite,
             rand_seed=args.rand_seed,

--- a/npdependency/graph_parser.py
+++ b/npdependency/graph_parser.py
@@ -885,6 +885,7 @@ def train(
         use_labels=parser.labels,
         use_tags=parser.tagset,
     )
+    devset: Optional[DependencyDataset]
     if dev_file is not None:
         devset = DependencyDataset(
             list(DepGraph.read_conll(dev_file)),

--- a/npdependency/main.py
+++ b/npdependency/main.py
@@ -6,6 +6,7 @@ import subprocess
 import sys
 import tempfile
 from typing import Dict, Generator, Optional, Union
+import warnings
 
 import click
 import click_pathlib

--- a/npdependency/main.py
+++ b/npdependency/main.py
@@ -171,7 +171,7 @@ def train(
         dev_file=dev_file,
         train_file=train_file,
         fasttext=fasttext,
-        max_tree_length=150,
+        max_tree_length=max_tree_length,
         model_path=model_path,
         overrides={"device": device},
         overwrite=overwrite,

--- a/npdependency/main.py
+++ b/npdependency/main.py
@@ -107,6 +107,7 @@ def parse(
         overrides={"device": device},
         raw=raw,
         strict=not ignore_unencodable,
+    )
 
 
 @cli.command(help="Train a parsing model")

--- a/npdependency/main.py
+++ b/npdependency/main.py
@@ -5,8 +5,7 @@ import pathlib
 import subprocess
 import sys
 import tempfile
-from typing import Generator, Optional, Union
-import warnings
+from typing import Dict, Generator, Optional, Union
 
 import click
 import click_pathlib
@@ -29,6 +28,15 @@ device_opt = click.option(
 )
 
 
+def make_metrics_table(metrics: Dict[str, float]) -> str:
+    column_width = max(7, *(len(k) for k in metrics.keys()))
+    keys, values = zip(*metrics.items())
+    headers = "|".join(k.center(column_width) for k in keys)
+    midrule = "|".join([f":{'-'*(column_width-2)}:"] * len(keys))
+    row = "|".join(f"{100*v:05.2f}".center(column_width) for v in values)
+    return "\n".join(f"|{r}|" for r in (headers, midrule, row))
+
+
 @contextlib.contextmanager
 def dir_manager(
     path: Optional[Union[pathlib.Path, str]] = None
@@ -44,7 +52,7 @@ def dir_manager(
         yield d_path
 
 
-@click.group()
+@click.group(help="A graph dependency parser")
 def cli():
     pass
 
@@ -99,7 +107,101 @@ def parse(
         overrides={"device": device},
         raw=raw,
         strict=not ignore_unencodable,
+
+
+@cli.command(help="Train a parsing model")
+@click.argument(
+    "config_file",
+    type=click_pathlib.Path(resolve_path=True, exists=True, dir_okay=False),
+)
+@click.argument(
+    "train_file",
+    type=click_pathlib.Path(resolve_path=True, exists=True, dir_okay=False),
+)
+@click.argument(
+    "output_dir",
+    type=click_pathlib.Path(resolve_path=True, file_okay=False, writable=True),
+)
+@click.option(
+    "--dev-file",
+    type=click_pathlib.Path(resolve_path=True, exists=True, dir_okay=False),
+    help="A CoNLL-U treebank to use as a development dataset.",
+)
+@click.option(
+    "--fasttext",
+    type=click_pathlib.Path(resolve_path=True, exists=True, dir_okay=False),
+    help="The path to either an existing FastText model or a raw text file to train one. If this option is absent, a model will be trained from the parsing train set.",
+)
+@click.option(
+    "--max-tree-length",
+    type=int,
+    help="The maximum length for trees to be taken into account in the training dataset.",
+)
+@click.option(
+    "--rand-seed",
+    type=int,
+    help="Force the random seed fo Python and Pytorch (see <https://pytorch.org/docs/stable/notes/randomness.html> for notes on reproducibility)",
+)
+@click.option(
+    "--test-file",
+    type=click_pathlib.Path(resolve_path=True, exists=True, dir_okay=False),
+    help="A CoNLL-U treebank to use as a test dataset.",
+)
+@click.option(
+    "--overwrite",
+    is_flag=True,
+    help="If a model already in the output directory, restart training from scratch instead of continuing.",
+)
+@device_opt
+def train(
+    config_file: pathlib.Path,
+    dev_file: Optional[pathlib.Path],
+    device: str,
+    fasttext: Optional[pathlib.Path],
+    max_tree_length: Optional[int],
+    output_dir: pathlib.Path,
+    overwrite: bool,
+    rand_seed: int,
+    test_file: Optional[pathlib.Path],
+    train_file: pathlib.Path,
+):
+    model_path = output_dir / "model"
+    graph_parser.train(
+        config_file=config_file,
+        dev_file=dev_file,
+        train_file=train_file,
+        fasttext=fasttext,
+        max_tree_length=150,
+        model_path=model_path,
+        overrides={"device": device},
+        overwrite=overwrite,
+        rand_seed=rand_seed,
     )
+    output_metrics = dict()
+    if dev_file is not None:
+        parsed_devset_path = output_dir / f"{dev_file.stem}.parsed.conllu"
+        graph_parser.parse(
+            model_path, dev_file, parsed_devset_path, overrides={"device": device}
+        )
+        gold_devset = evaluator.load_conllu_file(dev_file)
+        syst_devset = evaluator.load_conllu_file(parsed_devset_path)
+        dev_metrics = evaluator.evaluate(gold_devset, syst_devset)
+        for m in ("UPOS", "LAS"):
+            output_metrics[f"{m} (dev)"] = dev_metrics[m].f1
+
+    if test_file is not None:
+        parsed_testset_path = output_dir / f"{test_file.stem}.parsed.conllu"
+        graph_parser.parse(
+            model_path, test_file, parsed_testset_path, overrides={"device": device}
+        )
+        gold_testset = evaluator.load_conllu_file(test_file)
+        syst_testset = evaluator.load_conllu_file(parsed_testset_path)
+        test_metrics = evaluator.evaluate(gold_testset, syst_testset)
+        for m in ("UPOS", "LAS"):
+            output_metrics[f"{m} (test)"] = test_metrics[m].f1
+
+    if output_metrics:
+        click.echo(make_metrics_table(output_metrics))
 
 
 @cli.command(help="Evaluate a trained model")
@@ -114,7 +216,7 @@ def parse(
 @device_opt
 @click.option(
     "--intermediary-dir",
-    type=click_pathlib.Path(resolve_path=True, file_okay=False),
+    type=click_pathlib.Path(resolve_path=True, file_okay=False, writable=True),
     help="A directory where the parsed data will be stored, defaults to a temp dir",
 )
 @click.option(
@@ -148,10 +250,9 @@ def evaluate(
         syst_set = evaluator.load_conllu_file(str(output_file))
     metrics = evaluator.evaluate(gold_set, syst_set)
     if out_format == "md":
+        output_metrics = {n: metrics[n].f1 for n in ("UPOS", "UAS", "LAS")}
         click.echo(
-            "| UPOS  |  UAS  |  LAS  |\n"
-            "|:-----:|:-----:|:-----:|\n"
-            f"| {100*metrics['UPOS'].f1:.2f} | {100*metrics['UAS'].f1:.2f} | {100*metrics['LAS'].f1:.2f} |"
+            make_metrics_table(output_metrics)
         )
     elif out_format == "json":
         json.dump({m: metrics[m].f1 for m in ("UPOS", "UAS", "LAS")}, sys.stdout)

--- a/scripts/train_models.py
+++ b/scripts/train_models.py
@@ -59,7 +59,7 @@ def train_single_model(
     dev_metrics = evaluator.evaluate(gold_devset, syst_devset)
 
     gold_testset = evaluator.load_conllu_file(test_file)
-    syst_testset = evaluator.load_conllu_file(out_dir / f"{test_file.stem}.conllu.parsed")
+    syst_testset = evaluator.load_conllu_file(out_dir / f"{test_file.stem}.parsed.conllu")
     test_metrics = evaluator.evaluate(gold_testset, syst_testset)
 
     return TrainResults(

--- a/scripts/train_models.py
+++ b/scripts/train_models.py
@@ -25,7 +25,7 @@ class TrainResults(NamedTuple):
 def train_single_model(
     train_file: pathlib.Path,
     dev_file: pathlib.Path,
-    pred_file: pathlib.Path,
+    test_file: pathlib.Path,
     out_dir: pathlib.Path,
     config_path: pathlib.Path,
     device: str,
@@ -33,15 +33,15 @@ def train_single_model(
 ) -> TrainResults:
     subprocess.run(
         [
-            "graph_parser",
-            "--train_file",
+            "hopsparser",
+            "train",
+            str(config_path),
             str(train_file),
-            "--dev_file",
-            str(dev_file),
-            "--pred_file",
-            str(pred_file),
-            "--out_dir",
             str(out_dir),
+            "--dev-file",
+            str(dev_file),
+            "--test-file",
+            str(test_file),
             "--device",
             device,
             *(
@@ -50,7 +50,6 @@ def train_single_model(
                 if value
                 for a in (f"--{key}", value)
             ),
-            str(config_path),
         ],
         check=True,
     )
@@ -59,8 +58,8 @@ def train_single_model(
     syst_devset = evaluator.load_conllu_file(out_dir / f"{dev_file.name}.parsed")
     dev_metrics = evaluator.evaluate(gold_devset, syst_devset)
 
-    gold_testset = evaluator.load_conllu_file(pred_file)
-    syst_testset = evaluator.load_conllu_file(out_dir / f"{pred_file.name}.parsed")
+    gold_testset = evaluator.load_conllu_file(test_file)
+    syst_testset = evaluator.load_conllu_file(out_dir / f"{test_file.name}.parsed")
     test_metrics = evaluator.evaluate(gold_testset, syst_testset)
 
     return TrainResults(
@@ -194,7 +193,7 @@ def main(
             common_params = {
                 "train_file": t / "train.conllu",
                 "dev_file": t / "dev.conllu",
-                "pred_file": t / "test.conllu",
+                "test_file": t / "test.conllu",
                 "config_path": c,
             }
             run_base_name = f"{prefix}{t.name}-{c.stem}"

--- a/scripts/train_models.py
+++ b/scripts/train_models.py
@@ -274,6 +274,7 @@ def main(
             summary_file
         )
         best_dir = out_dir / "best"
+        best_dir.mkdir(exist_ok=True, parents=True)
         with open(best_dir / "models.md", "w") as out_stream:
             out_stream.write(
                 "| Model name | UPOS (dev) | LAS (dev) | UPOS (test) | LAS (test) | Download |\n"

--- a/scripts/train_models.py
+++ b/scripts/train_models.py
@@ -174,7 +174,7 @@ def main(
     configs = list(configs_dir.glob("*.yaml"))
     if rand_seeds is not None:
         args = [
-            ("rand_seed", [str(s) for s in rand_seeds]),
+            ("rand-seed", [str(s) for s in rand_seeds]),
             *(args if args is not None else []),
         ]
     additional_args_combinations: List[Dict[str, str]]
@@ -268,7 +268,7 @@ def main(
         df = pd.DataFrame.from_dict(df_dict, orient="index")
         df.to_csv(out_dir / "full_report.csv")
         grouped = df.groupby(
-            ["config", "treebank", *(a for a in args_names if a != "rand_seed")],
+            ["config", "treebank", *(a for a in args_names if a != "rand-seed")],
         )
         grouped[["dev_upos", "dev_las", "test_upos", "test_las"]].describe().to_csv(
             summary_file

--- a/scripts/train_models.py
+++ b/scripts/train_models.py
@@ -55,11 +55,11 @@ def train_single_model(
     )
 
     gold_devset = evaluator.load_conllu_file(dev_file)
-    syst_devset = evaluator.load_conllu_file(out_dir / f"{dev_file.name}.parsed")
+    syst_devset = evaluator.load_conllu_file(out_dir / f"{dev_file.stem}.parsed.conllu")
     dev_metrics = evaluator.evaluate(gold_devset, syst_devset)
 
     gold_testset = evaluator.load_conllu_file(test_file)
-    syst_testset = evaluator.load_conllu_file(out_dir / f"{test_file.name}.parsed")
+    syst_testset = evaluator.load_conllu_file(out_dir / f"{test_file.stem}.conllu.parsed")
     test_metrics = evaluator.evaluate(gold_testset, syst_testset)
 
     return TrainResults(

--- a/tox.ini
+++ b/tox.ini
@@ -8,11 +8,11 @@ allowlist_externals=cmp
 commands =
     graph_parser --train_file tests/fixtures/truncated-sv_talbanken-ud-dev.conllu --dev_file tests/fixtures/truncated-sv_talbanken-ud-dev.conllu --pred_file tests/fixtures/truncated-sv_talbanken-ud-dev.conllu --out_dir {envtmpdir}/nobert-smoketest-output-graph_parser tests/fixtures/toy_nobert.yaml
     hopsparser train tests/fixtures/toy_nobert.yaml tests/fixtures/truncated-sv_talbanken-ud-dev.conllu {envtmpdir}/nobert-smoketest-output --dev-file tests/fixtures/truncated-sv_talbanken-ud-dev.conllu --test-file tests/fixtures/truncated-sv_talbanken-ud-dev.conllu
-    hopsparser parse {envtmpdir}/nobert-smoketest-output/model tests/fixtures/truncated-sv_talbanken-ud-dev.conllu {envtmpdir}/nobert-smoketest-output/truncated-sv_talbanken-ud-dev.conllu.parsed2
-    cmp {envtmpdir}/nobert-smoketest-output/truncated-sv_talbanken-ud-dev.conllu.parsed2 {envtmpdir}/nobert-smoketest-output/truncated-sv_talbanken-ud-dev.conllu.parsed
-    hopsparser parse --raw {envtmpdir}/nobert-smoketest-output/model tests/fixtures/raw.txt {envtmpdir}/nobert-smoketest-output/raw.conllu.parsed2
-    hopsparser parse {envtmpdir}/nobert-smoketest-output/model {envtmpdir}/nobert-smoketest-output/raw.conllu.parsed2 {envtmpdir}/nobert-smoketest-output/raw.conllu.parsed2.reparsed
-    cmp {envtmpdir}/nobert-smoketest-output/raw.conllu.parsed2 {envtmpdir}/nobert-smoketest-output/raw.conllu.parsed2.reparsed
-    eval_parse -v tests/fixtures/truncated-sv_talbanken-ud-dev.conllu {envtmpdir}/nobert-smoketest-output/truncated-sv_talbanken-ud-dev.conllu.parsed
-    graph_parser --train_file tests/fixtures/truncated-sv_talbanken-ud-dev.conllu --dev_file tests/fixtures/truncated-sv_talbanken-ud-dev.conllu --pred_file tests/fixtures/truncated-sv_talbanken-ud-dev.conllu --out_dir {envtmpdir}/flaubert-smoketest-output tests/fixtures/toy_flaubert.yaml
-    eval_parse -v tests/fixtures/truncated-sv_talbanken-ud-dev.conllu {envtmpdir}/flaubert-smoketest-output/truncated-sv_talbanken-ud-dev.conllu.parsed
+    hopsparser parse {envtmpdir}/nobert-smoketest-output/model tests/fixtures/truncated-sv_talbanken-ud-dev.conllu {envtmpdir}/nobert-smoketest-output/truncated-sv_talbanken-ud-dev.parsed2.conllu
+    cmp {envtmpdir}/nobert-smoketest-output/truncated-sv_talbanken-ud-dev.parsed2.conllu {envtmpdir}/nobert-smoketest-output/truncated-sv_talbanken-ud-dev.parsed.conllu
+    hopsparser parse --raw {envtmpdir}/nobert-smoketest-output/model tests/fixtures/raw.txt {envtmpdir}/nobert-smoketest-output/raw.parsed2.conllu
+    hopsparser parse {envtmpdir}/nobert-smoketest-output/model {envtmpdir}/nobert-smoketest-output/raw.parsed2.conllu {envtmpdir}/nobert-smoketest-output/raw.parsed2.reparsed.conllu
+    cmp {envtmpdir}/nobert-smoketest-output/raw.parsed2.conllu {envtmpdir}/nobert-smoketest-output/raw.parsed2.reparsed.conllu
+    eval_parse -v tests/fixtures/truncated-sv_talbanken-ud-dev.conllu {envtmpdir}/nobert-smoketest-output/truncated-sv_talbanken-ud-dev.parsed.conllu
+    hopsparser train tests/fixtures/toy_flaubert.yaml tests/fixtures/truncated-sv_talbanken-ud-dev.conllu {envtmpdir}/flaubert-smoketest-output --dev-file tests/fixtures/truncated-sv_talbanken-ud-dev.conllu --test-file tests/fixtures/truncated-sv_talbanken-ud-dev.conllu
+    eval_parse -v tests/fixtures/truncated-sv_talbanken-ud-dev.conllu {envtmpdir}/flaubert-smoketest-output/truncated-sv_talbanken-ud-dev.parsed.conllu

--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,8 @@ skip_missing_interpreters = true
 [testenv]
 allowlist_externals=cmp
 commands =
-    graph_parser --train_file tests/fixtures/truncated-sv_talbanken-ud-dev.conllu --dev_file tests/fixtures/truncated-sv_talbanken-ud-dev.conllu --pred_file tests/fixtures/truncated-sv_talbanken-ud-dev.conllu --out_dir {envtmpdir}/nobert-smoketest-output tests/fixtures/toy_nobert.yaml
+    graph_parser --train_file tests/fixtures/truncated-sv_talbanken-ud-dev.conllu --dev_file tests/fixtures/truncated-sv_talbanken-ud-dev.conllu --pred_file tests/fixtures/truncated-sv_talbanken-ud-dev.conllu --out_dir {envtmpdir}/nobert-smoketest-output-graph_parser tests/fixtures/toy_nobert.yaml
+    hopsparser train tests/fixtures/toy_nobert.yaml tests/fixtures/truncated-sv_talbanken-ud-dev.conllu {envtmpdir}/nobert-smoketest-output --dev-file tests/fixtures/truncated-sv_talbanken-ud-dev.conllu --test-file tests/fixtures/truncated-sv_talbanken-ud-dev.conllu
     hopsparser parse {envtmpdir}/nobert-smoketest-output/model tests/fixtures/truncated-sv_talbanken-ud-dev.conllu {envtmpdir}/nobert-smoketest-output/truncated-sv_talbanken-ud-dev.conllu.parsed2
     cmp {envtmpdir}/nobert-smoketest-output/truncated-sv_talbanken-ud-dev.conllu.parsed2 {envtmpdir}/nobert-smoketest-output/truncated-sv_talbanken-ud-dev.conllu.parsed
     hopsparser parse --raw {envtmpdir}/nobert-smoketest-output/model tests/fixtures/raw.txt {envtmpdir}/nobert-smoketest-output/raw.conllu.parsed2


### PR DESCRIPTION
This adds the `hopsparser train` command to the CLI, finishing the rewriting of the existing `graph_parser` CLI. This is mostly serves to decouple the parser and the CLI we use to use it and paves the way to future developments. In essence this new commands works in the same way as the old interface but remove some legacy code paths and corner cases (for instance it now requires an explicit output directory where the trained models and the parsed dev and test corpora) and makes some things more flexible (such as making the dev corpus optional) or convenient (if provided, the performances of the test set will be reported in the output).

The legacy `graph_parser` interface it still available and will stay available (if deprecated) for v0.x in order to avoid breaking existing dependents, it will be removed v1.0.

## Added

A `hopsparser train` command that provides a nicer and cleaner training API
