### PR TITLE
Run tests in pytest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,7 +67,7 @@ jobs:
                 restore-keys: |
                   ${{ runner.os }}-transformers-
             - name: Run tox with tox-gh-actions
-              uses: ymyzk/tox-gh-actions@master
+              uses: ymyzk/tox-gh-actions@v2.5.0
     build_wheels:
         name: Build wheels on ${{ matrix.os }}
         runs-on: ${{ matrix.os }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,7 +69,7 @@ jobs:
             - name: Test with tox
               run: |
                   pip install tox
-                  tox -m 'not slow'
+                  tox
     build_wheels:
         name: Build wheels on ${{ matrix.os }}
         runs-on: ${{ matrix.os }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,7 +67,7 @@ jobs:
                 restore-keys: |
                   ${{ runner.os }}-transformers-
             - name: Run tox with tox-gh-actions
-              uses: ymyzk/tox-gh-actions@main
+              uses: ymyzk/tox-gh-actions@v2
     build_wheels:
         name: Build wheels on ${{ matrix.os }}
         runs-on: ${{ matrix.os }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,7 +67,7 @@ jobs:
                 restore-keys: |
                   ${{ runner.os }}-transformers-
             - name: Run tox with tox-gh-actions
-              uses: ymyzk/run-gh-actions@main
+              uses: ymyzk/run-tox-gh-actions@main
     build_wheels:
         name: Build wheels on ${{ matrix.os }}
         runs-on: ${{ matrix.os }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,7 +69,7 @@ jobs:
             - name: Test with tox
               run: |
                   pip install tox
-                  tox
+                  tox -m 'not slow'
     build_wheels:
         name: Build wheels on ${{ matrix.os }}
         runs-on: ${{ matrix.os }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,10 +66,8 @@ jobs:
                 key: ${{ runner.os }}-transformers-${{ hashFiles('**/setup.cfg') }}
                 restore-keys: |
                   ${{ runner.os }}-transformers-
-            - name: Test with tox
-              run: |
-                  pip install tox
-                  tox
+            - name: Run tox with tox-gh-actions
+              uses: ymyzk/tox-gh-actions@main
     build_wheels:
         name: Build wheels on ${{ matrix.os }}
         runs-on: ${{ matrix.os }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,7 +67,7 @@ jobs:
                 restore-keys: |
                   ${{ runner.os }}-transformers-
             - name: Run tox with tox-gh-actions
-              uses: ymyzk/tox-gh-actions@v2.5.0
+              uses: ymyzk/run-gh-actions@main
     build_wheels:
         name: Build wheels on ${{ matrix.os }}
         runs-on: ${{ matrix.os }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,7 +67,7 @@ jobs:
                 restore-keys: |
                   ${{ runner.os }}-transformers-
             - name: Run tox with tox-gh-actions
-              uses: ymyzk/tox-gh-actions@v2
+              uses: ymyzk/tox-gh-actions
     build_wheels:
         name: Build wheels on ${{ matrix.os }}
         runs-on: ${{ matrix.os }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,7 +67,7 @@ jobs:
                 restore-keys: |
                   ${{ runner.os }}-transformers-
             - name: Run tox with tox-gh-actions
-              uses: ymyzk/tox-gh-actions
+              uses: ymyzk/tox-gh-actions@master
     build_wheels:
         name: Build wheels on ${{ matrix.os }}
         runs-on: ${{ matrix.os }}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,0 @@
-fasttext
-torch
-transformers
-pyyaml

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,22 @@
+import pathlib
+import pytest
+
+
+@pytest.fixture
+def test_data_dir() -> pathlib.Path:
+    return pathlib.Path(__file__).parent / "fixtures"
+
+
+@pytest.fixture
+def treebank(test_data_dir: pathlib.Path) -> pathlib.Path:
+    return test_data_dir / "truncated-sv_talbanken-ud-dev.conllu"
+
+
+@pytest.fixture
+def raw_text(test_data_dir: pathlib.Path) -> pathlib.Path:
+    return test_data_dir / "raw.txt"
+
+
+@pytest.fixture(params=["toy_nobert", "toy_flaubert"])
+def train_config(test_data_dir: pathlib.Path, request) -> pathlib.Path:
+    return test_data_dir / f"{request.param}.yaml"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,6 +17,8 @@ def raw_text(test_data_dir: pathlib.Path) -> pathlib.Path:
     return test_data_dir / "raw.txt"
 
 
-@pytest.fixture(params=["toy_nobert", "toy_flaubert"])
+@pytest.fixture(
+    params=["toy_nobert", pytest.param("toy_flaubert", marks=pytest.mark.slow)]
+)
 def train_config(test_data_dir: pathlib.Path, request) -> pathlib.Path:
     return test_data_dir / f"{request.param}.yaml"

--- a/tests/test-requirements.txt
+++ b/tests/test-requirements.txt
@@ -1,0 +1,2 @@
+pytest
+pytest-console-scripts

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -1,0 +1,93 @@
+import filecmp
+import pathlib
+
+import pytest_console_scripts
+
+
+def test_train_parse(
+    raw_text: pathlib.Path,
+    script_runner: pytest_console_scripts.ScriptRunner,
+    tmp_path: pathlib.Path,
+    train_config: pathlib.Path,
+    treebank: pathlib.Path,
+):
+    ret = script_runner.run(
+        "hopsparser",
+        "train",
+        str(train_config),
+        str(treebank),
+        str(tmp_path),
+        "--dev-file",
+        str(treebank),
+        "--test-file",
+        str(treebank),
+    )
+    assert ret.success
+    ret = script_runner.run(
+        "hopsparser",
+        "parse",
+        str(tmp_path / "model"),
+        str(treebank),
+        str(tmp_path / f"{treebank.stem}.parsed2.conllu"),
+    )
+    assert ret.success
+    assert filecmp.cmp(
+        tmp_path / f"{treebank.stem}.parsed.conllu",
+        tmp_path / f"{treebank.stem}.parsed2.conllu",
+        shallow=False,
+    )
+    ret = script_runner.run(
+        "hopsparser",
+        "parse",
+        "--raw",
+        str(tmp_path / "model"),
+        str(raw_text),
+        str(tmp_path / f"{raw_text.stem}.parsed.conllu"),
+    )
+    assert ret.success
+    ret = script_runner.run(
+        "hopsparser",
+        "parse",
+        str(tmp_path / "model"),
+        str(tmp_path / f"{raw_text.stem}.parsed.conllu"),
+        str(tmp_path / f"{raw_text.stem}.reparsed.conllu"),
+    )
+    assert ret.success
+    assert filecmp.cmp(
+        str(tmp_path / f"{raw_text.stem}.parsed.conllu"),
+        str(tmp_path / f"{raw_text.stem}.reparsed.conllu"),
+        shallow=False,
+    )
+
+
+def test_graph_parser(
+    train_config: pathlib.Path,
+    treebank: pathlib.Path,
+    script_runner: pytest_console_scripts.ScriptRunner,
+    tmp_path: pathlib.Path,
+):
+    ret = script_runner.run(
+        "graph_parser",
+        str(train_config),
+        "--train_file",
+        str(treebank),
+        "--dev_file",
+        str(treebank),
+        "--pred_file",
+        str(treebank),
+        "--out_dir",
+        str(tmp_path),
+    )
+    assert ret.success
+
+
+def test_gold_evaluation(
+    script_runner: pytest_console_scripts.ScriptRunner, treebank: pathlib.Path
+):
+    ret = script_runner.run(
+        "eval_parse",
+        "-v",
+        str(treebank),
+        str(treebank),
+    )
+    assert ret.success

--- a/tox.ini
+++ b/tox.ini
@@ -12,3 +12,9 @@ commands = pytest --basetemp="{envtmpdir}" {posargs}
 
 [pytest]
 script_launch_mode = subprocess
+
+[gh-actions]
+python =
+    3.7: py37
+    3.8: py38
+    3.9: py39

--- a/tox.ini
+++ b/tox.ini
@@ -4,15 +4,11 @@ envlist = py39, py38, py37
 skip_missing_interpreters = true
 
 [testenv]
-allowlist_externals=cmp
-commands =
-    graph_parser --train_file tests/fixtures/truncated-sv_talbanken-ud-dev.conllu --dev_file tests/fixtures/truncated-sv_talbanken-ud-dev.conllu --pred_file tests/fixtures/truncated-sv_talbanken-ud-dev.conllu --out_dir {envtmpdir}/nobert-smoketest-output-graph_parser tests/fixtures/toy_nobert.yaml
-    hopsparser train tests/fixtures/toy_nobert.yaml tests/fixtures/truncated-sv_talbanken-ud-dev.conllu {envtmpdir}/nobert-smoketest-output --dev-file tests/fixtures/truncated-sv_talbanken-ud-dev.conllu --test-file tests/fixtures/truncated-sv_talbanken-ud-dev.conllu
-    hopsparser parse {envtmpdir}/nobert-smoketest-output/model tests/fixtures/truncated-sv_talbanken-ud-dev.conllu {envtmpdir}/nobert-smoketest-output/truncated-sv_talbanken-ud-dev.parsed2.conllu
-    cmp {envtmpdir}/nobert-smoketest-output/truncated-sv_talbanken-ud-dev.parsed2.conllu {envtmpdir}/nobert-smoketest-output/truncated-sv_talbanken-ud-dev.parsed.conllu
-    hopsparser parse --raw {envtmpdir}/nobert-smoketest-output/model tests/fixtures/raw.txt {envtmpdir}/nobert-smoketest-output/raw.parsed2.conllu
-    hopsparser parse {envtmpdir}/nobert-smoketest-output/model {envtmpdir}/nobert-smoketest-output/raw.parsed2.conllu {envtmpdir}/nobert-smoketest-output/raw.parsed2.reparsed.conllu
-    cmp {envtmpdir}/nobert-smoketest-output/raw.parsed2.conllu {envtmpdir}/nobert-smoketest-output/raw.parsed2.reparsed.conllu
-    eval_parse -v tests/fixtures/truncated-sv_talbanken-ud-dev.conllu {envtmpdir}/nobert-smoketest-output/truncated-sv_talbanken-ud-dev.parsed.conllu
-    hopsparser train tests/fixtures/toy_flaubert.yaml tests/fixtures/truncated-sv_talbanken-ud-dev.conllu {envtmpdir}/flaubert-smoketest-output --dev-file tests/fixtures/truncated-sv_talbanken-ud-dev.conllu --test-file tests/fixtures/truncated-sv_talbanken-ud-dev.conllu
-    eval_parse -v tests/fixtures/truncated-sv_talbanken-ud-dev.conllu {envtmpdir}/flaubert-smoketest-output/truncated-sv_talbanken-ud-dev.parsed.conllu
+changedir = tests
+deps =
+    pytest
+    pytest-console-scripts
+commands = pytest --basetemp="{envtmpdir}" {posargs}
+
+[pytest]
+script_launch_mode = subprocess


### PR DESCRIPTION
This moves our smoketests to pytest, with does not bring a lot of changes right now (although it makes us test slightly more things) but it will make future additions to our tests easier.

## Changed

- Tests now use pytest, it doesn't change anything for tox-based testing (the API stays the same) but the test outputs are cleaner and slow tests (those targeting FlauBERT) can now be skipped if desired.